### PR TITLE
Depreciated calls fix, add rollable buttons for Morale and Saves on NPCs, add damage application buttons

### DIFF
--- a/css/swords-wizardry.css
+++ b/css/swords-wizardry.css
@@ -527,4 +527,20 @@ input {
   margin-top: 5px;
 }
 
+.damage-target{
+  border:1px solid #666;
+  padding:5px;
+  margin-top:5px;
+}
+
+.damage-buttons{
+  display:flex;
+  gap:4px;
+  margin-top:4px;
+}
+
+.damage-buttons button{
+  flex:1;
+  font-size:11px;
+}
 /*# sourceMappingURL=swords-wizardry.css.map */

--- a/module/actor/actor-sheet.mjs
+++ b/module/actor/actor-sheet.mjs
@@ -7,7 +7,7 @@ import {
  * Extend the basic ActorSheet with some very simple modifications
  * @extends {ActorSheet}
  */
-export class SwordsWizardryActorSheet extends ActorSheet {
+export class SwordsWizardryActorSheet extends foundry.appv1.sheets.ActorSheet {
   /** @override */
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
@@ -162,6 +162,10 @@ export class SwordsWizardryActorSheet extends ActorSheet {
 
     html.on('click', '.save-roll', (ev) => {
       this.actor.rollSave();
+    });
+
+    html.on('click', '.morale-roll', (ev) => {
+      this.actor.rollMorale();
     });
 
     html.on('click', '.item-prepare', async (ev) => {

--- a/module/actor/actor.mjs
+++ b/module/actor/actor.mjs
@@ -1,4 +1,5 @@
 import { SaveRoll } from '../rolls/rolls.mjs';
+import { MoraleRoll } from '../rolls/rolls.mjs';
 
 export class SwordsWizardryActor extends Actor {
 
@@ -190,6 +191,12 @@ export class SwordsWizardryActor extends Actor {
 
   async rollSave() {
     const roll = new SaveRoll('d20', this);
+    roll.render();
+  }
+  
+ async rollMorale() {
+	if (this.type !== 'npc') return;
+    const roll = new MoraleRoll('2d6', this);
     roll.render();
   }
 

--- a/module/actor/npc-sheet.hbs
+++ b/module/actor/npc-sheet.hbs
@@ -33,7 +33,11 @@
           </div>
         </div>
         <div class="resource">
-          <label for="system.morale" class="resource-label">{{localize 'SWORDS_WIZARDRY.Stats.Morale'}}</label>
+          <label for="system.morale" class="resource-label">{{localize 'SWORDS_WIZARDRY.Stats.Morale'}}
+		  <a class='morale-roll' data-roll-type='item'>
+              <i class="fas fa-dice-d20"></i>
+          </a>
+		  </label>
           <div class="resource-content flexrow flex-center flex-between">
             <input type="text" name="system.morale" value="{{system.morale}}" data-dtype="Number"/>
           </div>
@@ -41,17 +45,21 @@
         <div class="resource grid-span-3">
           <label for="system.special" class="resource-label">{{localize 'SWORDS_WIZARDRY.NPCSheet.Main.Special'}}</label>
           <div class="resource-content flexrow flex-center flex-between">
-            <input type="text" name="system.special" value="{{system.special}}" data-dtype="Text"/>
+            <input type="text" name="system.special" value="{{system.special}}" data-dtype="String"/>
           </div>
         </div>
         <div class="resource grid-span-2">
           <label for="system.alignment" class="resource-label">{{localize 'SWORDS_WIZARDRY.Stats.Alignment'}}</label>
           <div class="resource-content flexrow flex-center flex-between">
-            <input type="text" name="system.alignment" value="{{system.alignment}}" data-dtype="Text"/>
+            <input type="text" name="system.alignment" value="{{system.alignment}}" data-dtype="String"/>
           </div>
         </div>
        <div class="resource">
-          <label for="system.save" class="resource-label">{{localize 'SWORDS_WIZARDRY.Stats.SavingThrow.long'}}</label>
+          <label for="system.save" class="resource-label">{{localize 'SWORDS_WIZARDRY.Stats.SavingThrow.long'}}
+		  <a class='save-roll' data-roll-type='item'>
+            <i class="fas fa-dice-d20"></i>
+          </a>
+		  </label>
           <div class="resource-content flexrow flex-center flex-between">
             <input type="text" name="system.save.value" value="{{system.save.value}}" data-dtype="Number"/>
           </div>
@@ -72,13 +80,13 @@
         <div class="resource grid-span-3">
           <label for="system.numberEncountered" class="resource-label">{{localize 'SWORDS_WIZARDRY.Stats.NumberEncountered.long'}}</label>
           <div class="resource-content flexrow flex-center flex-between">
-            <input type="text" name="system.numberEncountered" value="{{system.numberEncountered}}" data-dtype="Text"/>
+            <input type="text" name="system.numberEncountered" value="{{system.numberEncountered}}" data-dtype="String"/>
           </div>
         </div>
         <div class="resource">
           <label for="system.percentInLair" class="resource-label">{{localize 'SWORDS_WIZARDRY.Stats.PercentInLair.abbr'}}</label>
           <div class="resource-content flexrow flex-center flex-between">
-            <input type="text" name="system.percentInLair" value="{{system.percentInLair}}" data-dtype="Text"/>
+            <input type="text" name="system.percentInLair" value="{{system.percentInLair}}" data-dtype="String"/>
           </div>
         </div>
       </div>

--- a/module/combat/combat.mjs
+++ b/module/combat/combat.mjs
@@ -1,4 +1,4 @@
-export class SwordsWizardryCombatTracker extends CombatTracker {
+export class SwordsWizardryCombatTracker extends foundry.applications.sidebar.tabs.CombatTracker {
   /** @override
     * we do this so we can inject "game" into the combat.turns and turns
     *

--- a/module/helpers/overrides.mjs
+++ b/module/helpers/overrides.mjs
@@ -1,4 +1,5 @@
 import { DamageRoll } from '../rolls/rolls.mjs';
+import { rpc } from './rpc.mjs';
 
 export class SwordsWizardryChatMessage extends ChatMessage {
   constructor(data){
@@ -10,8 +11,8 @@ export class SwordsWizardryChatMessage extends ChatMessage {
     }
   }
 
-  async getHTML() {
-    const html = await super.getHTML();
+  async renderHTML() {
+    const html = await super.renderHTML();
     this.activateListeners(html);
     return html;
   }
@@ -36,5 +37,140 @@ export class SwordsWizardryChatMessage extends ChatMessage {
       const roll = new DamageRoll(damageFormula, rollData);
       await roll.render();
     });
+	
+	$(html).on('click', '.apply-damage', async (e) => {
+
+	  if (!game.user.isGM) {
+		ui.notifications.warn("Only GM can apply damage");
+		return;
+	  }
+	  const button = e.currentTarget;
+	  const action = e.currentTarget.dataset.action;
+	  const targetId = e.currentTarget.dataset.targetId;
+
+	  let amount = Number(e.currentTarget.dataset.amount);
+
+	  if (action === "half") {
+		amount = Math.floor(amount / 2);
+	  }
+
+	  if (action === "double") {
+		amount = amount * 2;
+	  }
+
+	  if (action === "heal") {
+		amount = amount * -1;
+	  }
+	  
+	  const target = canvas.tokens.get(targetId);
+
+	  if (!target) return;
+
+	  let oldHP = target.actor.system.hp.value;
+	  let newHP = target.actor.system.hp.value;
+      newHP -= amount;
+
+
+	  await rpc({
+		recipient: 'GM',
+		target: target.id,
+		operation: 'damage',
+		amount: amount,
+		data: {
+		  system: {
+			hp: {
+			  value: newHP
+			}
+		  }
+		}
+	  });
+
+
+	const messageId = $(button)
+	  .closest(".message")
+	  .data("messageId");
+
+	const message = game.messages.get(messageId);
+
+	if (!message) return;
+
+	const applied =
+	  foundry.utils.deepClone(
+		message.getFlag(
+		  "swords-wizardry",
+		  "appliedDamage"
+		) || {}
+	  );
+
+	applied[targetId] = {
+	  action: action,
+	  amount: amount,
+	  oldHP: oldHP,
+	  newHP: newHP
+	};
+
+	await message.setFlag(
+	  "swords-wizardry",
+	  "appliedDamage",
+	  applied
+	);
+
+	await message.update({});
+	
+	});
   }
 }
+
+Hooks.on("renderChatMessageHTML", (message, html, data) => {
+
+  const appliedDamage =
+    message.getFlag(
+      "swords-wizardry",
+      "appliedDamage"
+    ) || {};
+
+  const targets =
+    html.querySelectorAll(".damage-target");
+
+  if(!targets.length) return;
+
+  targets.forEach(targetElement => {
+
+    const button = targetElement.querySelector(".apply-damage");
+    if(!button) return;
+
+    const targetId = button.dataset.targetId;
+    if(!appliedDamage[targetId]) return;
+
+    const result = appliedDamage[targetId];
+
+    let label = result.action;
+
+    if(result.action==="damage") label="Damage";
+    if(result.action==="heal") label="Healing";
+    if(result.action==="half") label="Half Damage";
+    if(result.action==="double") label="Double Damage";
+
+    const resultDiv = targetElement.querySelector(".damage-result");
+    if(!resultDiv) return;
+
+/* Don't tell the players how much HP is remaining, they deserve nothing so useful!
+    resultDiv.innerHTML = `
+      Applied ${label}: ${result.amount}<br>
+      HP: ${result.oldHP} → ${result.newHP}
+    `;
+*/
+    resultDiv.innerHTML = `
+      Applied ${label}: ${result.amount}<br>
+    `;
+
+    const buttons =
+      targetElement.querySelectorAll("button");
+
+    buttons.forEach(b=>{
+      b.disabled = true;
+    });
+
+  });
+
+});

--- a/module/helpers/templates.mjs
+++ b/module/helpers/templates.mjs
@@ -4,7 +4,7 @@
  * @return {Promise}
  */
 export const preloadHandlebarsTemplates = async function () {
-  return loadTemplates([
+  return foundry.applications.handlebars.loadTemplates([
     'systems/swords-wizardry/module/actor/features.hbs',
     'systems/swords-wizardry/module/actor/weapons.hbs',
     'systems/swords-wizardry/module/actor/items.hbs',

--- a/module/item/item-sheet.mjs
+++ b/module/item/item-sheet.mjs
@@ -3,7 +3,7 @@ import {
   prepareActiveEffectCategories,
 } from '../helpers/effects.mjs';
 
-export class SwordsWizardryItemSheet extends ItemSheet {
+export class SwordsWizardryItemSheet extends foundry.appv1.sheets.ItemSheet {
   /** @override */
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {

--- a/module/rolls/damage-roll-sheet.hbs
+++ b/module/rolls/damage-roll-sheet.hbs
@@ -1,8 +1,59 @@
 {{ log 'damage-roll-sheet' this}}
 <div class="swords-wizardry">
   <h3>{{localize "SWORDS_WIZARDRY.Chat.Damage"}}: {{item.name}}</h3>
-  <a class="inline-result"><span>{{{roll}}}</span></a>
-  {{#if item.system.specialDamage}}
-  <div class="damage-special-text" >{{localize "SWORDS_WIZARDRY.Chat.Special"}}: {{item.system.specialDamage}}</div>
+
+  <a class="inline-result">
+    <span>{{{roll}}}</span>
+  </a>
+
+  {{#if targets}}
+  <div class="damage-targets">
+
+    {{#each targets}}
+    <div class="damage-target">
+      <div class="target-name">
+        {{name}}
+      </div>
+
+      <div class="damage-buttons">
+
+        <button class="apply-damage"
+          data-action="damage"
+          data-target-id="{{id}}"
+          data-amount="{{../total}}"
+		  {{#if (lookup ../appliedDamage id)}}disabled{{/if}}>
+          Damage
+        </button>
+
+        <button class="apply-damage"
+          data-action="half"
+          data-target-id="{{id}}"
+          data-amount="{{../total}}"
+		  {{#if (lookup ../appliedDamage id)}}disabled{{/if}}>
+          Half
+        </button>
+
+        <button class="apply-damage"
+          data-action="double"
+          data-target-id="{{id}}"
+          data-amount="{{../total}}"
+		  {{#if (lookup ../appliedDamage id)}}disabled{{/if}}>
+          Double
+        </button>
+
+        <button class="apply-damage"
+          data-action="heal"
+          data-target-id="{{id}}"
+          data-amount="{{../total}}"
+		  {{#if (lookup ../appliedDamage id)}}disabled{{/if}}>
+          Heal
+        </button>
+      </div>
+	  <div class="damage-result"></div>
+    </div>
+    {{/each}}
+
+  </div>
   {{/if}}
+
 </div>

--- a/module/rolls/morale-roll-sheet.hbs
+++ b/module/rolls/morale-roll-sheet.hbs
@@ -1,0 +1,7 @@
+{{ log 'save-roll-sheet' this}}
+<h3>{{ localize 'SWORDS_WIZARDRY.Stats.Morale' }}</h3>
+<a class="inline-result"><span>{{{roll}}}</span></a>
+<div>
+{{localize "SWORDS_WIZARDRY.Chat.Target"}} <= {{target}}
+{{# if success}}{{localize "SWORDS_WIZARDRY.Chat.Success"}}{{else}}{{localize "SWORDS_WIZARDRY.Chat.Failure"}}{{/if}}
+</div>

--- a/module/rolls/rolls.mjs
+++ b/module/rolls/rolls.mjs
@@ -47,7 +47,7 @@ export class AttackRoll extends Roll {
       missedTargets: this.missedTargets,
       damageFormula: this.data.damageFormula
     }
-    const resultsHtml = await renderTemplate(template, chatData);
+    const resultsHtml = await foundry.applications.handlebars.renderTemplate(template, chatData);
     const msg = await SwordsWizardryChatMessage.create({
       rolls: [this],
       rollMode: rollMode,
@@ -61,6 +61,9 @@ export class AttackRoll extends Roll {
 export class DamageRoll extends Roll {
   async evaluate() {
     const result = await super.evaluate();
+	
+	/* Commenting out the old auto-application of damage to add a GM-clickable button */
+	/*
     game.user.targets.forEach(async (target) => {
       await rpc({
         recipient: 'GM',
@@ -70,6 +73,7 @@ export class DamageRoll extends Roll {
         data: { system: { hp: { value: target.actor.system.hp.value - result.total } } }
       });
     });
+	*/
     return result;
   }
 
@@ -79,15 +83,39 @@ export class DamageRoll extends Roll {
     if (!this._evaluated) await this.evaluate();
     const rollHtml = await super.render();
     const template = 'systems/swords-wizardry/module/rolls/damage-roll-sheet.hbs';
+	
+	/* 3/23/26: pass targets to chat box */
+	const targets = Array.from(game.user.targets).map(t => ({
+	  id: t.id,
+	  name: t.name,
+	  hp: t.actor.system.hp.value
+	}));
+
+	const message = this.message;
+
+	let appliedDamage = {};
+
+	if(message){
+	  appliedDamage =
+		message.getFlag(
+		  "swords-wizardry",
+		  "appliedDamage"
+		) || {};
+	}
+
     const chatData = {
       item: this.data.item,
       actor: this.data.actor,
       roll: rollHtml,
       total: this.total,
+	  targets: targets,
+	  appliedDamage:appliedDamage,
     };
-    const resultsHtml = await renderTemplate(template, chatData);
+	
+    const resultsHtml = await foundry.applications.handlebars.renderTemplate(template, chatData);
     const msg = await SwordsWizardryChatMessage.create({
-      rollMode: rollMode,
+      rolls: [this],
+	  rollMode: rollMode,
       user: game.user._id,
       speaker: speaker,
       content: resultsHtml
@@ -121,9 +149,10 @@ export class FeatureRoll extends Roll {
       roll: rollHtml,
       ...this.data
     };
-    const resultsHtml = await renderTemplate(template, chatData);
+    const resultsHtml = await foundry.applications.handlebars.renderTemplate(template, chatData);
     const msg = await SwordsWizardryChatMessage.create({
-      rollMode: rollMode,
+      rolls: [this],
+	  rollMode: rollMode,
       user: game.user._id,
       speaker: speaker,
       content: resultsHtml
@@ -135,7 +164,8 @@ export class FeatureRoll extends Roll {
 export class SaveRoll extends Roll {
   constructor(formula, rollData={}, options={}) {
     super(formula, rollData, options);
-    this.save = rollData.system.save || { value: 15 };
+    this.save = rollData?.system?.save ?? { value: 15 };
+    if (!this.save.value) this.save.value = 15;
   }
 
   async evaluate() {
@@ -157,9 +187,53 @@ export class SaveRoll extends Roll {
       roll: rollHtml,
       ...this.data
     };
-    const resultsHtml = await renderTemplate(template, chatData);
+    const resultsHtml = await foundry.applications.handlebars.renderTemplate(template, chatData);
     const msg = await SwordsWizardryChatMessage.create({
-      rollMode: rollMode,
+      rolls: [this],
+	  rollMode: rollMode,
+      user: game.user._id,
+      speaker: speaker,
+      content: resultsHtml
+    });
+  }
+}
+
+export class MoraleRoll extends Roll {
+  constructor(formula, rollData={}, options={}) {
+    super(formula, rollData, options);
+    this.morale = rollData?.system?.morale ?? 7;
+  }
+
+  async evaluate() {
+    const result = await super.evaluate();
+    result.success = result.total <= this.morale;
+    return result;
+  }
+
+  async render(options) {
+	if (!game.user.isGM) {
+	  return rpc({
+		recipient: "GM",
+		operation: "moraleRoll",
+		actorId: this.data.actor.id
+	  });
+	}
+    const speaker = ChatMessage.getSpeaker({ actor: this.data.actor });
+    if (!this._evaluated) await this.evaluate();
+    const rollHtml = await super.render();
+    const template = 'systems/swords-wizardry/module/rolls/morale-roll-sheet.hbs';
+    const chatData = {
+      total: this.total,
+      target: this.morale,
+      success: this.success,
+      roll: rollHtml,
+      ...this.data
+    };
+    const resultsHtml = await foundry.applications.handlebars.renderTemplate(template, chatData);
+    const msg = await SwordsWizardryChatMessage.create({
+      rolls: [this],
+	  rollMode: CONST.DICE_ROLL_MODES.GMROLL,
+	  whisper: ChatMessage.getWhisperRecipients("GM"),
       user: game.user._id,
       speaker: speaker,
       content: resultsHtml

--- a/module/swords-wizardry.mjs
+++ b/module/swords-wizardry.mjs
@@ -11,7 +11,7 @@ import { ImportManager } from './importer/importer.mjs';
 import { CharacterCreatorManager } from './character-creator/character-creator.mjs';
 import { SwordsWizardryChatMessage } from './helpers/overrides.mjs';
 
-import { AttackRoll, DamageRoll, FeatureRoll, SaveRoll } from './rolls/rolls.mjs';
+import { AttackRoll, DamageRoll, FeatureRoll, SaveRoll, MoraleRoll } from './rolls/rolls.mjs';
 // Import document classes.
 import { SwordsWizardryActor } from './actor/actor.mjs';
 import { SwordsWizardryItem } from './item/item.mjs';
@@ -56,7 +56,8 @@ Hooks.once('init', function() {
     AttackRoll,
     DamageRoll,
     FeatureRoll,
-    SaveRoll
+    SaveRoll,
+	MoraleRoll
   ];
 
   // Active Effects are never copied to the Actor,
@@ -64,14 +65,14 @@ Hooks.once('init', function() {
   // if the transfer property on the Active Effect is true.
   CONFIG.ActiveEffect.legacyTransferral = false;
 
-  Actors.unregisterSheet('core', ActorSheet);
-  Actors.registerSheet('swords-wizardry', SwordsWizardryActorSheet, {
+  foundry.documents.collections.Actors.unregisterSheet('core', foundry.appv1.sheets.ActorSheet);
+  foundry.documents.collections.Actors.registerSheet('swords-wizardry', SwordsWizardryActorSheet, {
     makeDefault: true,
     label: 'SWORDS_WIZARDRY.SheetLabels.Actor',
   });
 
-  Items.unregisterSheet('core', ItemSheet);
-  Items.registerSheet('swords-wizardry', SwordsWizardryItemSheet, {
+  foundry.documents.collections.Items.unregisterSheet('core', foundry.appv1.sheets.ItemSheet);
+  foundry.documents.collections.Items.registerSheet('swords-wizardry', SwordsWizardryItemSheet, {
     makeDefault: true,
     label: 'SWORDS_WIZARDRY.SheetLabels.Item',
   });


### PR DESCRIPTION
Decided to try my hand at fixing the issue I raised, and explored adding my own damage application button feature.

I'm sorry if I'm doing this wrong, it's my first attempt at github so I have no idea if I'm doing this right.

Anyway:
 - Depreciated calls for old v1 elements were fixed.  

<img width="1077" height="1941" alt="image" src="https://github.com/user-attachments/assets/36961c99-0be0-4a0b-b88e-d48427e4eda7" />

 - Rollable buttons were added to the NPC actor sheet for Morale checks and Saving throws.  

<img width="840" height="912" alt="image" src="https://github.com/user-attachments/assets/8d94d239-4715-43e6-92c9-71b5d2d8160f" />

 - I also added "rolls: [this]" to the other roll types that were missing it, so it would trigger the dice rolling sound, and also the 3D dice in mods like Dice So Nice.  

<img width="1481" height="1127" alt="image" src="https://github.com/user-attachments/assets/8a75aef5-0b64-4bec-a5c1-f3d0183ff956" />

 - NPC actor sheets were generating warnings when the sheet was closed because they were using 'Text' as a datatype instead of 'String' for alignment, Number Appearing, and Special so those were switched to String.  It was an issue with variable casting.
 
  - Damage application buttons were added to the DamageRoll method to allow the GM to apply the rolled damage, half damage, double damage, or apply healing based on the rolled number.  Right now the buttons are disabled after one application to prevent multiple clicks, but that could easily be adjusted or removed.
  
<img width="373" height="542" alt="image" src="https://github.com/user-attachments/assets/0aee95b3-abef-4701-8c16-b480bc9c6e52" />
