### PR TITLE
fix: hud re-renders causing duplicate rolls

### DIFF
--- a/module/hud/hud.mjs
+++ b/module/hud/hud.mjs
@@ -1,6 +1,8 @@
 const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 
 export class CombatHud extends HandlebarsApplicationMixin(ApplicationV2) {
+  EVENT_NAMESPACE = '.swords-wizardry-combat-hud';
+
   RERENDER_EVENTS = [
     'createItem',
     'updateItem',
@@ -60,19 +62,22 @@ export class CombatHud extends HandlebarsApplicationMixin(ApplicationV2) {
   _onRender(context, options) {
     // TODO de-jQuery-ify
     const $html = $(this.element);
+    const clickEvent = `click${this.EVENT_NAMESPACE}`;
 
-    $html.on('click', '.save-roll', (ev) => {
+    $html.off(this.EVENT_NAMESPACE);
+
+    $html.on(clickEvent, '.save-roll', (ev) => {
       const item = this.actor.rollSave();
     });
 
-    $html.on('click', '.item', (ev) => {
+    $html.on(clickEvent, '.item', (ev) => {
       const li = $(ev.currentTarget);
       const item = this.actor.items.get(li.data('itemId'));
       if (!item) return;
       item.roll();
     });
 
-    $html.on('click', '.item-feature', (ev) => {
+    $html.on(clickEvent, '.item-feature', (ev) => {
       const li = $(ev.currentTarget);
       const itemId = li.data('itemId');
       const item = this.actor.items.get(itemId);
@@ -80,7 +85,7 @@ export class CombatHud extends HandlebarsApplicationMixin(ApplicationV2) {
       item.roll();
     });
 
-    $html.on('click', '.item-cast', (ev) => {
+    $html.on(clickEvent, '.item-cast', (ev) => {
       const li = $(ev.currentTarget);
       const itemId = li.data('itemId');
       const item = this.actor.items.get(itemId);
@@ -123,8 +128,10 @@ export class CombatHud extends HandlebarsApplicationMixin(ApplicationV2) {
   static async activateHud(token, selected) {
     if (game.user.combatHuds?.length) {
       const controlled = canvas.tokens.controlled;
-      for (const hud of game.user.combatHuds) {
-        if (!controlled.includes(token)) {
+      for (const hud of Array.from(game.user.combatHuds)) {
+        const isCurrentToken = hud.token === token;
+        const isControlled = controlled.includes(hud.token);
+        if (!isControlled || isCurrentToken) {
           await hud.close();
         }
       }

--- a/test/hud.test.mjs
+++ b/test/hud.test.mjs
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+globalThis.foundry = {
+  applications: {
+    api: {
+      ApplicationV2: class {
+        constructor() {
+          this.element = { handlers: [] };
+        }
+
+        async render() {
+          this._onRender?.({}, {});
+          return this;
+        }
+
+        async close() {
+          return this;
+        }
+      },
+      HandlebarsApplicationMixin: (Base) => Base
+    }
+  }
+};
+
+const hooks = {
+  nextId: 1,
+  registered: new Map(),
+  on(event, fn) {
+    const id = this.nextId++;
+    this.registered.set(id, { event, fn });
+    return id;
+  },
+  off(_event, id) {
+    this.registered.delete(id);
+  }
+};
+
+globalThis.Hooks = hooks;
+
+globalThis.$ = (element) => ({
+  on(event, selector, handler) {
+    element.handlers.push({ event, selector, handler });
+    return this;
+  },
+  off(namespace) {
+    element.handlers = element.handlers.filter(
+      (handler) => !handler.event.endsWith(namespace)
+    );
+    return this;
+  },
+  data(name) {
+    return element.dataset?.[name];
+  }
+});
+
+globalThis.document = {
+  documentElement: {
+    clientHeight: 900
+  }
+};
+
+const { CombatHud } = await import('../module/hud/hud.mjs');
+
+function actorWithItems(items = []) {
+  return {
+    items,
+    system: {
+      spellSlots: null
+    }
+  };
+}
+
+function token(id, actor = actorWithItems()) {
+  return { id, actor };
+}
+
+function resetFoundryState(controlled = []) {
+  globalThis.game = {
+    settings: {
+      get() {
+        return false;
+      }
+    },
+    user: {
+      combatHuds: []
+    }
+  };
+  globalThis.canvas = {
+    tokens: { controlled }
+  };
+  hooks.nextId = 1;
+  hooks.registered.clear();
+}
+
+test('activating an already selected token replaces the previous HUD instance', async () => {
+  const selected = token('token-a', actorWithItems());
+  resetFoundryState([selected]);
+
+  await CombatHud.activateHud(selected, true);
+  await CombatHud.activateHud(selected, true);
+
+  assert.equal(game.user.combatHuds.length, 1);
+  assert.equal(game.user.combatHuds[0].token, selected);
+  assert.equal(hooks.registered.size, 4);
+});
+
+test('rerendering a HUD keeps one delegated click handler per action', () => {
+  const selected = token('token-a', actorWithItems());
+  resetFoundryState([selected]);
+  const hud = new CombatHud(selected);
+
+  hud._onRender({}, {});
+  hud._onRender({}, {});
+
+  assert.deepEqual(
+    hud.element.handlers.map((handler) => `${handler.event} ${handler.selector}`),
+    [
+      'click.swords-wizardry-combat-hud .save-roll',
+      'click.swords-wizardry-combat-hud .item',
+      'click.swords-wizardry-combat-hud .item-feature',
+      'click.swords-wizardry-combat-hud .item-cast'
+    ]
+  );
+});


### PR DESCRIPTION
Fixes the combat HUD creating duplicate roll actions after re-renders or repeated token selection. 
issue: https://github.com/vonkow/swords-wizardry/issues/22

The HUD was binding delegated click handlers every time it rendered, so item updates could stack multiple handlers on the same HUD element. It could also create multiple HUD instances for the same selected token. Together, that caused HUD weapon clicks to roll more than once.

Changes:
- Namespace HUD click handlers and clear existing HUD handlers before rebinding.
- Close stale or same-token HUD instances before creating a new HUD.
- Add regression tests for duplicate HUD instances and duplicate click handlers.