### PR TITLE
Add interactive spell effects and improved spell cards

### DIFF
--- a/css/swords-wizardry.css
+++ b/css/swords-wizardry.css
@@ -24,6 +24,30 @@
 }
 /*$font-header: 'Inter';*/
 /* Global styles */
+@font-face {
+  font-family: "Libre Baskerville";
+  src: url("/systems/swords-wizardry/assets/fonts/LibreBaskerville/LibreBaskerville-Regular.ttf");
+}
+@font-face {
+  font-family: "Libre Baskerville";
+  font-weight: bold;
+  src: url("/systems/swords-wizardry/assets/fonts/LibreBaskerville/LibreBaskerville-Bold.ttf");
+}
+@font-face {
+  font-family: "Libre Baskerville";
+  font-style: italic;
+  src: url("/systems/swords-wizardry/assets/fonts/LibreBaskerville/LibreBaskerville-Italic.ttf");
+}
+@font-face {
+  font-family: "Inter";
+  src: url("/systems/swords-wizardry/assets/fonts/Inter/Inter_24pt-Regular.ttf");
+}
+@font-face {
+  font-family: "Inter";
+  font-weight: 800;
+  src: url("/systems/swords-wizardry/assets/fonts/Inter/Inter_24pt-ExtraBold.ttf");
+}
+/*$font-header: 'Inter';*/
 body {
   font-family: "Libre Baskerville";
   font-size: 10pt;
@@ -306,56 +330,34 @@ input {
 }
 
 /* Styles limited to swords-wizardry sheets */
-.swords-wizardry {
-  /*
-  .sheet-tabs {
-    flex: 0;
-  }
-
-  .sheet-body,
-  .sheet-body .tab,
-  .sheet-body .tab .editor {
-    //height: 100%;
-  }
-
-  .editor {
-    min-height: 19.6em;
-    height: 100%;
-  }
-
-  .editor-container {
-      margin: 0;
-  }
-
-  .tox {
-    .tox-editor-container {
-      background: $c-white;
-    }
-
-    .tox-edit-area {
-      padding: 0 8px;
-    }
-  }
-  */
-  /*
-  .resource-label, .modifier-label {
-      font-weight: bold;
-  }
-
-  .resource-value, .modifier-value {
-      text-align: center;
-  }
-
-  .abilities, .modifiers {
-      .resource-label, .modifier-label {
-          //margin-top: 5px;
-      }
-  }
-
-  */
-}
 .swords-wizardry .window-content {
   overflow: scroll;
+}
+@font-face {
+  font-family: "Libre Baskerville";
+  src: url("/systems/swords-wizardry/assets/fonts/LibreBaskerville/LibreBaskerville-Regular.ttf");
+}
+@font-face {
+  font-family: "Libre Baskerville";
+  font-weight: bold;
+  src: url("/systems/swords-wizardry/assets/fonts/LibreBaskerville/LibreBaskerville-Bold.ttf");
+}
+@font-face {
+  font-family: "Libre Baskerville";
+  font-style: italic;
+  src: url("/systems/swords-wizardry/assets/fonts/LibreBaskerville/LibreBaskerville-Italic.ttf");
+}
+@font-face {
+  font-family: "Inter";
+  src: url("/systems/swords-wizardry/assets/fonts/Inter/Inter_24pt-Regular.ttf");
+}
+@font-face {
+  font-family: "Inter";
+  font-weight: 800;
+  src: url("/systems/swords-wizardry/assets/fonts/Inter/Inter_24pt-ExtraBold.ttf");
+}
+.swords-wizardry {
+  /*$font-header: 'Inter';*/
 }
 .swords-wizardry .combat-hud-name {
   font-family: "Libre Baskerville";
@@ -420,6 +422,38 @@ input {
   width: 100%;
   height: 100%;
   margin: 0;
+}
+.swords-wizardry {
+  /*
+  .sheet-tabs {
+    flex: 0;
+  }
+
+  .sheet-body,
+  .sheet-body .tab,
+  .sheet-body .tab .editor {
+    //height: 100%;
+  }
+
+  .editor {
+    min-height: 19.6em;
+    height: 100%;
+  }
+
+  .editor-container {
+      margin: 0;
+  }
+
+  .tox {
+    .tox-editor-container {
+      background: $c-white;
+    }
+
+    .tox-edit-area {
+      padding: 0 8px;
+    }
+  }
+  */
 }
 .swords-wizardry .items-header {
   height: 28px;
@@ -522,6 +556,32 @@ input {
   padding-left: 5px;
   text-align: left;
 }
+@font-face {
+  font-family: "Libre Baskerville";
+  src: url("/systems/swords-wizardry/assets/fonts/LibreBaskerville/LibreBaskerville-Regular.ttf");
+}
+@font-face {
+  font-family: "Libre Baskerville";
+  font-weight: bold;
+  src: url("/systems/swords-wizardry/assets/fonts/LibreBaskerville/LibreBaskerville-Bold.ttf");
+}
+@font-face {
+  font-family: "Libre Baskerville";
+  font-style: italic;
+  src: url("/systems/swords-wizardry/assets/fonts/LibreBaskerville/LibreBaskerville-Italic.ttf");
+}
+@font-face {
+  font-family: "Inter";
+  src: url("/systems/swords-wizardry/assets/fonts/Inter/Inter_24pt-Regular.ttf");
+}
+@font-face {
+  font-family: "Inter";
+  font-weight: 800;
+  src: url("/systems/swords-wizardry/assets/fonts/Inter/Inter_24pt-ExtraBold.ttf");
+}
+.swords-wizardry {
+  /*$font-header: 'Inter';*/
+}
 .swords-wizardry .damage-roll-button {
   font-family: "Libre Baskerville";
   width: 100%;
@@ -586,5 +646,268 @@ input {
 .swords-wizardry .toggle i {
   margin-left: -3px;
 }
+.swords-wizardry {
+  /*
+  .resource-label, .modifier-label {
+      font-weight: bold;
+  }
 
-/*# sourceMappingURL=swords-wizardry.css.map */
+  .resource-value, .modifier-value {
+      text-align: center;
+  }
+
+  .abilities, .modifiers {
+      .resource-label, .modifier-label {
+          //margin-top: 5px;
+      }
+  }
+
+  */
+}
+.swords-wizardry .sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+.swords-wizardry button:focus-visible,
+.swords-wizardry input:focus-visible,
+.swords-wizardry select:focus-visible,
+.swords-wizardry textarea:focus-visible {
+  outline: 2px solid var(--color-shadow-primary, #7a4d00);
+  outline-offset: 2px;
+}
+.swords-wizardry .image-button {
+  width: 26px;
+  height: 26px;
+  min-height: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+.swords-wizardry .image-button img {
+  display: block;
+}
+.swords-wizardry .spell-casting-fields {
+  align-items: end;
+}
+.swords-wizardry .spell-actions-summary {
+  margin-block: 0.5rem;
+}
+.swords-wizardry .spell-actions-summary__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+.swords-wizardry .spell-actions-summary__header h3 {
+  margin: 0;
+}
+.swords-wizardry .spell-actions-summary__header button {
+  width: auto;
+  white-space: nowrap;
+}
+.swords-wizardry .spell-actions-summary ol {
+  margin-block: 0.4rem;
+  padding-inline-start: 1.5rem;
+}
+.swords-wizardry .spell-actions-summary code {
+  display: inline-block;
+  overflow-wrap: anywhere;
+}
+.swords-wizardry .spell-actions-summary__empty {
+  font-style: italic;
+}
+.swords-wizardry .spell-sheet-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-block: 0.5rem;
+}
+.swords-wizardry .spell-sheet-actions button {
+  flex: 1;
+}
+.swords-wizardry .spell-action-editor__body {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: 100%;
+}
+.swords-wizardry .spell-action-editor__toolbar, .swords-wizardry .spell-action-editor__footer, .swords-wizardry .spell-action-editor__action > header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+.swords-wizardry .spell-action-editor__toolbar button, .swords-wizardry .spell-action-editor__footer button, .swords-wizardry .spell-action-editor__order-controls button {
+  width: auto;
+}
+.swords-wizardry .spell-action-editor__error,
+.swords-wizardry .spell-action-editor .spell-card__warning {
+  border: 1px solid var(--color-level-error, #a00000);
+  padding: 0.5rem;
+}
+.swords-wizardry .spell-action-editor__list {
+  flex: 1;
+  overflow: auto;
+  margin: 0.5rem 0;
+  padding: 0;
+  list-style: none;
+}
+.swords-wizardry .spell-action-editor__action {
+  border: 1px solid var(--color-border-light-primary, #777);
+  border-radius: 4px;
+  padding: 0.6rem;
+  margin-block-end: 0.6rem;
+}
+.swords-wizardry .spell-action-editor__action h3 {
+  margin: 0;
+}
+.swords-wizardry .spell-action-editor__order-controls {
+  display: flex;
+  gap: 0.25rem;
+}
+.swords-wizardry .spell-action-editor__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+  margin-block-start: 0.5rem;
+}
+.swords-wizardry .spell-action-editor__grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+.swords-wizardry .spell-action-editor__grid [hidden] {
+  display: none;
+}
+.swords-wizardry .spell-action-editor__grid .grid-span-2 {
+  grid-column: 1/-1;
+}
+.swords-wizardry .spell-action-editor__grid textarea {
+  min-height: 3.5rem;
+  resize: vertical;
+}
+.swords-wizardry .spell-card__header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.swords-wizardry .spell-card__header img {
+  flex: 0 0 auto;
+  object-fit: cover;
+}
+.swords-wizardry .spell-card__header h3,
+.swords-wizardry .spell-card__header p {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+.swords-wizardry .spell-card__metadata {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.25rem 0.75rem;
+  margin-block: 0.6rem;
+}
+.swords-wizardry .spell-card__metadata div {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.35rem;
+  min-width: 0;
+}
+.swords-wizardry .spell-card__metadata dt {
+  font-weight: 400;
+}
+.swords-wizardry .spell-card__metadata dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+.swords-wizardry .spell-card__description, .swords-wizardry .spell-card__actions {
+  margin-block-start: 0.6rem;
+}
+.swords-wizardry .spell-card__action-list {
+  display: grid;
+  gap: 0.35rem;
+}
+.swords-wizardry .spell-card__action-list button {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  min-width: 0;
+}
+.swords-wizardry .spell-card__action-list code {
+  overflow-wrap: anywhere;
+}
+.swords-wizardry .spell-card__action-list .hint {
+  margin: -0.2rem 0 0.25rem;
+}
+.swords-wizardry .spell-card__warning {
+  border-inline-start: 4px solid var(--color-level-warning, #9a6700);
+  padding: 0.4rem 0.6rem;
+}
+.swords-wizardry .spell-result__roll {
+  margin-block: 0.5rem;
+}
+.swords-wizardry .spell-result__targets ol {
+  padding-inline-start: 1.5rem;
+}
+.swords-wizardry .spell-result__targets.damage-targets ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.swords-wizardry .spell-result__target {
+  margin-block: 0.4rem;
+}
+.swords-wizardry .spell-result__target-name {
+  font-weight: 700;
+}
+.swords-wizardry .spell-result__target-status, .swords-wizardry .spell-result__application-status {
+  display: block;
+}
+.swords-wizardry .spell-result__application-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-block-start: 0.25rem;
+}
+.swords-wizardry .spell-result__application-controls button {
+  flex: 1 1 7rem;
+}
+.swords-wizardry .spell-result__application-controls.damage-buttons {
+  flex-wrap: nowrap;
+  gap: 4px;
+  margin-top: 4px;
+}
+.swords-wizardry .spell-result__application-controls.damage-buttons button {
+  flex: 1;
+  min-width: 0;
+  font-size: 11px;
+}
+@media (max-width: 520px) {
+  .swords-wizardry .spell-action-editor__grid,
+  .swords-wizardry .spell-card__metadata {
+    grid-template-columns: 1fr;
+  }
+  .swords-wizardry .spell-action-editor__grid .grid-span-2 {
+    grid-column: auto;
+  }
+}
+
+.swords-wizardry.spell-card,
+.swords-wizardry.spell-card h3,
+.swords-wizardry.spell-card h4,
+.swords-wizardry.spell-card p,
+.swords-wizardry.spell-card dt,
+.swords-wizardry.spell-card dd,
+.swords-wizardry.spell-card strong {
+  color: inherit;
+  text-shadow: none;
+}
+.swords-wizardry.spell-card button {
+  text-shadow: none;
+}

--- a/lang/de.json
+++ b/lang/de.json
@@ -10,6 +10,153 @@
       "Success": "Success",
       "Failure": "Failure"
     },
+    "Spell": {
+      "Actions": {
+        "Post": "Anzeigen",
+        "Cast": "Wirken",
+        "Continue": "Weiter",
+        "PostNamed": "{spell} anzeigen",
+        "CastNamed": "{spell} wirken",
+        "PrepareNamed": "{spell} vorbereiten",
+        "ApplyDamage": "Schaden anwenden",
+        "ApplyHalfDamage": "Halben Schaden anwenden",
+        "ApplyDoubleDamage": "Doppelten Schaden anwenden",
+        "ApplyHealing": "Heilung anwenden",
+        "Damage": "Schaden",
+        "Half": "Hälfte",
+        "Double": "Doppelt"
+      },
+      "CasterLevelSources": {
+        "automatic": "Bei Bedarf fragen",
+        "fixed": "Feste Stufe",
+        "prompt": "Immer fragen",
+        "characterLevel": "Charakterstufe",
+        "npcHitDice": "NSC-Trefferwürfel"
+      },
+      "CasterLevelPrompt": {
+        "Title": "Zauberstufe",
+        "Label": "Zauberstufe"
+      },
+      "ActionKinds": {
+        "damage": "Schaden",
+        "healing": "Heilung",
+        "attack": "Angriff",
+        "roll": "Wurf",
+        "effect": "Regelverweis",
+        "manual": "Beschreibung"
+      },
+      "TargetModes": {
+        "none": "Kein Ziel",
+        "single": "Ein Ziel",
+        "selected": "Ausgewählte Ziele",
+        "manual": "Manuelle Zielwahl"
+      },
+      "SaveOutcomes": {
+        "none": "Kein Rettungswurf",
+        "negates": "Negiert",
+        "half": "Halbiert",
+        "partial": "Teilweise",
+        "custom": "Benutzerdefiniert"
+      },
+      "AttackModes": {
+        "none": "Kein Angriff",
+        "melee": "Nahkampf",
+        "missile": "Fernkampf",
+        "custom": "Benutzerdefiniert"
+      },
+      "Editor": {
+        "Title": "Zaubereffekte: {spell}",
+        "Help": "Füge Würfe oder Anweisungen für die Chatkarte des Zaubers hinzu. Es werden nur Optionen für die gewählte Effektart angezeigt.",
+        "ActionCount": "{count} von {maximum} Effekten",
+        "AddAction": "Effekt hinzufügen",
+        "NewAction": "Neuer Effekt",
+        "ActionHeading": "Effekt {number}",
+        "MoveUp": "Effekt nach oben",
+        "MoveDown": "Effekt nach unten",
+        "RemoveAction": "Effekt entfernen",
+        "Label": "Name",
+        "Kind": "Effektart",
+        "Formula": "Würfelformel",
+        "TargetMode": "Ziele",
+        "SaveOutcome": "Ergebnis des Rettungswurfs",
+        "SaveNotes": "Hinweise zum Rettungswurf",
+        "AttackMode": "Angriffsart",
+        "AttackNotes": "Hinweise zum Angriff",
+        "EffectReference": "Regelverweis",
+        "Notes": "Notizen",
+        "Empty": "Dieser Zauber hat keine Zaubereffekte.",
+        "Save": "Zaubereffekte speichern"
+      },
+      "Card": {
+        "CastBy": "Gewirkt von {caster}",
+        "CasterLevel": "Zauberstufe",
+        "Description": "Zauberbeschreibung",
+        "RollResult": "Wurfergebnis",
+        "Save": "Rettungswurf",
+        "Attack": "Angriff",
+        "AttackOutcome": {
+          "hit": "Treffer",
+          "miss": "Verfehlt",
+          "manual": "Manuell abwickeln",
+          "missing": "Ziel nicht verfügbar"
+        },
+        "Effect": "Effekt",
+        "Targets": "Ziele",
+        "MissingTarget": "Ziel ist nicht mehr verfügbar",
+        "Applied": "Angewendet: {amount}",
+        "ConsumptionFailed": "Die Zauberkarte wurde angezeigt, aber der vorbereitete Zauber wurde nicht verbraucht. Bitte den Charakter prüfen."
+      },
+      "Notifications": {
+        "AuditFailed": "Der Zauber wurde verbraucht, aber die Zauberkarte konnte nicht aktualisiert werden.",
+        "AutoApplicationFailed": "Automatischer Zauberschaden oder automatische Heilung konnte bei {count} Ziel(en) nicht angewendet werden."
+      },
+      "Validation": {
+        "UNKNOWN": "Der Zaubereffekt konnte nicht abgeschlossen werden.",
+        "UNKNOWN_FIELD": "Der Zaubereffekt enthält ein nicht unterstütztes Feld.",
+        "INVALID_ACTION_KIND": "Bitte eine gültige Effektart wählen.",
+        "FORMULA_REQUIRED": "Dieser Effekt benötigt eine Würfelformel.",
+        "INVALID_TARGET_MODE": "Bitte eine gültige Zielart wählen.",
+        "INVALID_SAVE_OUTCOME": "Bitte ein gültiges Rettungswurfergebnis wählen.",
+        "SAVE_NOTES_REQUIRED": "Bitte Hinweise zu diesem Rettungswurf hinzufügen.",
+        "INVALID_ATTACK_MODE": "Bitte eine gültige Angriffsart wählen.",
+        "ATTACK_MODE_REQUIRED": "Angriffseffekte benötigen eine Angriffsart.",
+        "ATTACK_NOTES_REQUIRED": "Benutzerdefinierte Angriffe benötigen Hinweise.",
+        "EFFECT_REFERENCE_OR_NOTES_REQUIRED": "Effekte mit Regelverweis benötigen einen Verweis oder Notizen.",
+        "TOO_MANY_ACTIONS": "Dieser Zauber hat zu viele Effekte.",
+        "DUPLICATE_ACTION_ID": "Jeder Zaubereffekt benötigt eine eindeutige ID.",
+        "UNSUPPORTED_FORMULA_REFERENCE": "Die Formel verwendet einen nicht unterstützten Datenverweis.",
+        "INVALID_LEVEL_SOURCE": "Bitte eine gültige Quelle der Zauberstufe wählen.",
+        "FIXED_LEVEL_REQUIRED": "Bitte eine feste Zauberstufe eingeben.",
+        "INVALID_FIXED_LEVEL": "Die feste Zauberstufe muss eine ganze Zahl von 1 bis 100 sein.",
+        "INVALID_CASTER_LEVEL": "Die Zauberstufe muss eine ganze Zahl von 1 bis 100 sein.",
+        "ABILITY_MODIFIER_REQUIRED": "Diese Formel benötigt einen Attributsmodifikator, aber keiner ist verfügbar.",
+        "ITEM_NOT_FOUND": "Der Zauber ist nicht mehr verfügbar.",
+        "NOT_AUTHORIZED": "Du darfst diesen Zaubereffekt nicht verwenden.",
+        "CAST_IN_PROGRESS": "Dieser Zauber wird bereits gewirkt.",
+        "SPELL_NOT_PREPARED": "Dieser Zauber ist derzeit nicht vorbereitet.",
+        "MESSAGE_CREATE_FAILED": "Die Zauberkarte konnte nicht erstellt werden; der Zauber wurde nicht verbraucht.",
+        "STALE_PREPARATION": "Die vorbereiteten Zauber wurden während des Wirkens geändert.",
+        "CONSUMPTION_FAILED": "Die Zauberkarte wurde erstellt, aber der Zauber konnte nicht verbraucht werden.",
+        "ACTION_NOT_FOUND": "Dieser Zaubereffekt existiert nicht mehr.",
+        "STALE_ACTION": "Dieser Zaubereffekt wurde nach dem Anzeigen der Karte geändert.",
+        "ACTION_IN_PROGRESS": "Dieser Zaubereffekt wird bereits abgewickelt.",
+        "SINGLE_TARGET_REQUIRED": "Bitte genau ein Ziel auswählen.",
+        "TARGET_REQUIRED": "Bitte mindestens ein Ziel auswählen.",
+        "NON_FINITE_ROLL": "Der Zauberwurf ergab keinen endlichen Wert.",
+        "INVALID_ROLL_FORMULA": "Die Würfelformel des Zaubers ist ungültig.",
+        "GM_REQUIRED": "Nur die Spielleitung kann Schaden oder Heilung anwenden.",
+        "INVALID_MESSAGE_SCHEMA": "Diese Zauberkarte verwendet eine nicht unterstützte Datenversion.",
+        "ACTION_NOT_APPLICABLE": "Dieser Effekt kann keine Trefferpunkte ändern.",
+        "ACTION_KIND_MISMATCH": "Die Anwendung passt nicht zum Zaubereffekt.",
+        "TARGET_NOT_IN_RESULT": "Das Ziel gehört nicht zu diesem Zauberergebnis.",
+        "APPLICATION_IN_PROGRESS": "Dieses Ergebnis wird bereits angewendet.",
+        "TARGET_NOT_FOUND": "Das Ziel ist nicht mehr verfügbar.",
+        "TARGET_UPDATE_FAILED": "Das Ziel konnte nicht aktualisiert werden.",
+        "AUDIT_FAILED_ROLLED_BACK": "Die Protokollierung schlug fehl; die Trefferpunktänderung wurde zurückgenommen.",
+        "ROLLBACK_FAILED": "Protokollierung und Rücknahme sind fehlgeschlagen. Trefferpunkte sofort prüfen.",
+        "APPLICATION_FAILED": "Schaden oder Heilung konnte nicht angewendet werden."
+      }
+    },
     "NPCSheet": {
       "Main": {
         "Name": "Name",
@@ -64,6 +211,7 @@
         "Gold": "Goldmünzen",
         "Platinum": "Platinmünzen",
         "Silver": "Silbermünzen",
+        "Items": "Gegenstände",
         "Other": "Sonstiges",
         "Table": {
           "Create": "Neuen Gegenstand hinzufügen",
@@ -159,7 +307,7 @@
         "long": "Höchstzahl Spezialisten",
         "abbr": "Max. Spezialisten"
       },
-      "RetainerMoraleAdjustment": { "long": "Retainer Morale Adjustment", "short": "retainer" }
+      "RetainerMoraleAdjustment": { "long": "Moralmodifikator für Gefolgsleute", "abbr": "Gefolgsleute" }
     },
     "SheetLabels": {
       "Actor": "SwordsWizardry Charakterbogen",
@@ -174,6 +322,19 @@
           "Effects": "Effekte"
         }
       },
+      "Armor": {
+        "Attributes": {
+          "EffectOnAC": "Auswirkung auf RK"
+        },
+        "Name": "Name",
+        "Quantity": "Anzahl",
+        "Gold": "Gold",
+        "Tabs": {
+          "Attributes": "Eigenschaften",
+          "Description": "Beschreibung"
+        },
+        "Weight": "Gewicht"
+      },
       "Item": {
         "Attributes": {
           "ToHitModifier": "To Hit Modifier",
@@ -185,6 +346,7 @@
         },
         "Name": "Name",
         "Quantity": "Anzahl",
+        "Gold": "Gold",
         "Tabs": {
           "Attributes": "Eigenschaften",
           "Description": "Beschreibung"
@@ -196,6 +358,11 @@
         "Level": "Zaubergrad",
         "Range": "Range",
         "Duration": "Duration",
+        "CasterLevelSource": "Quelle der Zauberstufe",
+        "FixedCasterLevel": "Feste Zauberstufe",
+        "Actions": "Zaubereffekte",
+        "EditActions": "Zaubereffekte bearbeiten",
+        "NoActions": "Keine Zaubereffekte",
         "Tabs": {
           "Attributes": "Eigenschaften",
           "Description": "Beschreibung"
@@ -208,7 +375,8 @@
           "DamageRollFormula": "Schadensberechnung",
           "Range": "Reichweite",
           "Missile": "Missile Weapon?",
-          "RateOfFire": "Feuerrate"
+          "RateOfFire": "Feuerrate",
+          "SpecialDamage": "Besonderer Schaden"
         },
         "Name": "Name",
         "Quantity": "Anzahl",
@@ -236,6 +404,7 @@
   "TYPES": {
     "Actor": {
       "character": "SC",
+      "container": "Behälter",
       "npc": "NSC"
     },
     "Item": {
@@ -247,6 +416,7 @@
     }
   },
   "New": {
+    "armor": "Neue Rüstung",
     "item": "Neuer Gegenstand",
     "feature": "Neues Merkmal",
     "spell": "Neuer Zauber",

--- a/lang/en.json
+++ b/lang/en.json
@@ -10,6 +10,153 @@
       "Success": "Success",
       "Failure": "Failure"
     },
+    "Spell": {
+      "Actions": {
+        "Post": "Post",
+        "Cast": "Cast",
+        "Continue": "Continue",
+        "PostNamed": "Post {spell}",
+        "CastNamed": "Cast {spell}",
+        "PrepareNamed": "Prepare {spell}",
+        "ApplyDamage": "Apply Damage",
+        "ApplyHalfDamage": "Apply Half Damage",
+        "ApplyDoubleDamage": "Apply Double Damage",
+        "ApplyHealing": "Apply Healing",
+        "Damage": "Damage",
+        "Half": "Half",
+        "Double": "Double"
+      },
+      "CasterLevelSources": {
+        "automatic": "Ask when needed",
+        "fixed": "Fixed level",
+        "prompt": "Always ask",
+        "characterLevel": "Character level",
+        "npcHitDice": "NPC Hit Dice"
+      },
+      "CasterLevelPrompt": {
+        "Title": "Caster Level",
+        "Label": "Caster level"
+      },
+      "ActionKinds": {
+        "damage": "Damage",
+        "healing": "Healing",
+        "attack": "Attack",
+        "roll": "Roll",
+        "effect": "Rules reference",
+        "manual": "Description"
+      },
+      "TargetModes": {
+        "none": "No target",
+        "single": "Single target",
+        "selected": "Selected targets",
+        "manual": "Manual targeting"
+      },
+      "SaveOutcomes": {
+        "none": "No save",
+        "negates": "Negates",
+        "half": "Half",
+        "partial": "Partial",
+        "custom": "Custom"
+      },
+      "AttackModes": {
+        "none": "No attack",
+        "melee": "Melee",
+        "missile": "Missile",
+        "custom": "Custom"
+      },
+      "Editor": {
+        "Title": "Spell Effects: {spell}",
+        "Help": "Add the rolls or instructions shown on this spell's chat card. Only options used by the selected effect type are shown.",
+        "ActionCount": "{count} of {maximum} effects",
+        "AddAction": "Add Effect",
+        "NewAction": "New Effect",
+        "ActionHeading": "Effect {number}",
+        "MoveUp": "Move effect up",
+        "MoveDown": "Move effect down",
+        "RemoveAction": "Remove effect",
+        "Label": "Name",
+        "Kind": "Effect type",
+        "Formula": "Roll formula",
+        "TargetMode": "Targets",
+        "SaveOutcome": "Saving throw outcome",
+        "SaveNotes": "Saving throw guidance",
+        "AttackMode": "Attack mode",
+        "AttackNotes": "Attack guidance",
+        "EffectReference": "Rules reference",
+        "Notes": "Notes",
+        "Empty": "This spell has no spell effects.",
+        "Save": "Save Spell Effects"
+      },
+      "Card": {
+        "CastBy": "Cast by {caster}",
+        "CasterLevel": "Caster Level",
+        "Description": "Spell description",
+        "RollResult": "Roll result",
+        "Save": "Save",
+        "Attack": "Attack",
+        "AttackOutcome": {
+          "hit": "Hit",
+          "miss": "Miss",
+          "manual": "Resolve manually",
+          "missing": "Target unavailable"
+        },
+        "Effect": "Effect",
+        "Targets": "Targets",
+        "MissingTarget": "Target is no longer available",
+        "Applied": "Applied: {amount}",
+        "ConsumptionFailed": "The spell card was posted, but the prepared spell was not consumed. Review the Actor before continuing."
+      },
+      "Notifications": {
+        "AuditFailed": "The prepared spell was consumed, but the chat-card audit could not be updated.",
+        "AutoApplicationFailed": "Automatic spell damage or healing could not be applied to {count} target(s)."
+      },
+      "Validation": {
+        "UNKNOWN": "The spell effect could not be completed.",
+        "UNKNOWN_FIELD": "The spell effect contains an unsupported field.",
+        "INVALID_ACTION_KIND": "Choose a valid spell effect type.",
+        "FORMULA_REQUIRED": "This effect requires a roll formula.",
+        "INVALID_TARGET_MODE": "Choose a valid target mode.",
+        "INVALID_SAVE_OUTCOME": "Choose a valid saving throw outcome.",
+        "SAVE_NOTES_REQUIRED": "Add guidance for this saving throw outcome.",
+        "INVALID_ATTACK_MODE": "Choose a valid attack mode.",
+        "ATTACK_MODE_REQUIRED": "Attack effects require an attack mode.",
+        "ATTACK_NOTES_REQUIRED": "Custom attacks require guidance.",
+        "EFFECT_REFERENCE_OR_NOTES_REQUIRED": "Referenced effects require a rules reference or notes.",
+        "TOO_MANY_ACTIONS": "This spell has too many effects.",
+        "DUPLICATE_ACTION_ID": "Each spell effect must have a unique ID.",
+        "UNSUPPORTED_FORMULA_REFERENCE": "The formula uses an unsupported data reference.",
+        "INVALID_LEVEL_SOURCE": "Choose a valid caster-level source.",
+        "FIXED_LEVEL_REQUIRED": "Enter a fixed caster level.",
+        "INVALID_FIXED_LEVEL": "The fixed caster level must be a whole number from 1 to 100.",
+        "INVALID_CASTER_LEVEL": "Caster level must be a whole number from 1 to 100.",
+        "ABILITY_MODIFIER_REQUIRED": "This formula requires an ability modifier, but none is available.",
+        "ITEM_NOT_FOUND": "The spell Item is no longer available.",
+        "NOT_AUTHORIZED": "You are not allowed to use this spell effect.",
+        "CAST_IN_PROGRESS": "This spell is already being cast.",
+        "SPELL_NOT_PREPARED": "This spell is not currently prepared.",
+        "MESSAGE_CREATE_FAILED": "The spell card could not be created; preparation was not consumed.",
+        "STALE_PREPARATION": "Prepared spells changed before casting completed.",
+        "CONSUMPTION_FAILED": "The spell card was created, but preparation could not be consumed.",
+        "ACTION_NOT_FOUND": "This spell effect no longer exists.",
+        "STALE_ACTION": "This spell effect changed after the card was posted.",
+        "ACTION_IN_PROGRESS": "This spell effect is already being resolved.",
+        "SINGLE_TARGET_REQUIRED": "Select exactly one target.",
+        "TARGET_REQUIRED": "Select at least one target.",
+        "NON_FINITE_ROLL": "The spell roll did not produce a finite total.",
+        "INVALID_ROLL_FORMULA": "The spell roll formula is invalid.",
+        "GM_REQUIRED": "Only a GM can apply damage or healing.",
+        "INVALID_MESSAGE_SCHEMA": "This spell card uses an unsupported data version.",
+        "ACTION_NOT_APPLICABLE": "This effect cannot change hit points.",
+        "ACTION_KIND_MISMATCH": "The requested application does not match the spell effect.",
+        "TARGET_NOT_IN_RESULT": "The target is not part of this spell result.",
+        "APPLICATION_IN_PROGRESS": "This result is already being applied.",
+        "TARGET_NOT_FOUND": "The target is no longer available.",
+        "TARGET_UPDATE_FAILED": "The target could not be updated.",
+        "AUDIT_FAILED_ROLLED_BACK": "The audit update failed, so the hit-point change was rolled back.",
+        "ROLLBACK_FAILED": "The audit and rollback both failed. Review the target's hit points immediately.",
+        "APPLICATION_FAILED": "Damage or healing could not be applied."
+      }
+    },
     "NPCSheet": {
       "Main": {
         "Name": "Name",
@@ -208,6 +355,11 @@
         "Level": "Level",
         "Range": "Range",
         "Duration": "Duration",
+        "CasterLevelSource": "Caster level source",
+        "FixedCasterLevel": "Fixed caster level",
+        "Actions": "Spell Effects",
+        "EditActions": "Edit Spell Effects",
+        "NoActions": "No spell effects",
         "Tabs": {
           "Attributes": "Attributes",
           "Description": "Description"

--- a/lang/es.json
+++ b/lang/es.json
@@ -10,6 +10,153 @@
       "Success": "Éxito",
       "Failure": "Fallo"
     },
+    "Spell": {
+      "Actions": {
+        "Post": "Publicar",
+        "Cast": "Lanzar",
+        "Continue": "Continuar",
+        "PostNamed": "Publicar {spell}",
+        "CastNamed": "Lanzar {spell}",
+        "PrepareNamed": "Memorizar {spell}",
+        "ApplyDamage": "Aplicar daño",
+        "ApplyHalfDamage": "Aplicar medio daño",
+        "ApplyDoubleDamage": "Aplicar daño doble",
+        "ApplyHealing": "Aplicar curación",
+        "Damage": "Daño",
+        "Half": "Mitad",
+        "Double": "Doble"
+      },
+      "CasterLevelSources": {
+        "automatic": "Preguntar cuando sea necesario",
+        "fixed": "Nivel fijo",
+        "prompt": "Preguntar siempre",
+        "characterLevel": "Nivel de personaje",
+        "npcHitDice": "Dados de golpe del PNJ"
+      },
+      "CasterLevelPrompt": {
+        "Title": "Nivel de lanzador",
+        "Label": "Nivel de lanzador"
+      },
+      "ActionKinds": {
+        "damage": "Daño",
+        "healing": "Curación",
+        "attack": "Ataque",
+        "roll": "Tirada",
+        "effect": "Referencia de reglas",
+        "manual": "Descripción"
+      },
+      "TargetModes": {
+        "none": "Sin objetivo",
+        "single": "Un objetivo",
+        "selected": "Objetivos seleccionados",
+        "manual": "Selección manual"
+      },
+      "SaveOutcomes": {
+        "none": "Sin salvación",
+        "negates": "Anula",
+        "half": "Mitad",
+        "partial": "Parcial",
+        "custom": "Personalizado"
+      },
+      "AttackModes": {
+        "none": "Sin ataque",
+        "melee": "Cuerpo a cuerpo",
+        "missile": "Proyectil",
+        "custom": "Personalizado"
+      },
+      "Editor": {
+        "Title": "Efectos del conjuro: {spell}",
+        "Help": "Añade las tiradas o instrucciones de la tarjeta de chat del conjuro. Solo se muestran las opciones del tipo de efecto seleccionado.",
+        "ActionCount": "{count} de {maximum} efectos",
+        "AddAction": "Añadir efecto",
+        "NewAction": "Nuevo efecto",
+        "ActionHeading": "Efecto {number}",
+        "MoveUp": "Subir efecto",
+        "MoveDown": "Bajar efecto",
+        "RemoveAction": "Eliminar efecto",
+        "Label": "Nombre",
+        "Kind": "Tipo de efecto",
+        "Formula": "Fórmula de tirada",
+        "TargetMode": "Objetivos",
+        "SaveOutcome": "Resultado de salvación",
+        "SaveNotes": "Indicaciones de salvación",
+        "AttackMode": "Tipo de ataque",
+        "AttackNotes": "Indicaciones de ataque",
+        "EffectReference": "Referencia de reglas",
+        "Notes": "Notas",
+        "Empty": "Este conjuro no tiene efectos.",
+        "Save": "Guardar efectos del conjuro"
+      },
+      "Card": {
+        "CastBy": "Lanzado por {caster}",
+        "CasterLevel": "Nivel de lanzador",
+        "Description": "Descripción del conjuro",
+        "RollResult": "Resultado de tirada",
+        "Save": "Salvación",
+        "Attack": "Ataque",
+        "AttackOutcome": {
+          "hit": "Impacto",
+          "miss": "Fallo",
+          "manual": "Resolver manualmente",
+          "missing": "Objetivo no disponible"
+        },
+        "Effect": "Efecto",
+        "Targets": "Objetivos",
+        "MissingTarget": "El objetivo ya no está disponible",
+        "Applied": "Aplicado: {amount}",
+        "ConsumptionFailed": "La tarjeta se publicó, pero el conjuro memorizado no se consumió. Revisa el Actor antes de continuar."
+      },
+      "Notifications": {
+        "AuditFailed": "El conjuro se consumió, pero no se pudo actualizar la auditoría de la tarjeta.",
+        "AutoApplicationFailed": "No se pudo aplicar automáticamente el daño o la curación del conjuro a {count} objetivo(s)."
+      },
+      "Validation": {
+        "UNKNOWN": "No se pudo completar el efecto del conjuro.",
+        "UNKNOWN_FIELD": "El efecto contiene un campo no compatible.",
+        "INVALID_ACTION_KIND": "Elige un tipo de efecto válido.",
+        "FORMULA_REQUIRED": "Este efecto necesita una fórmula de tirada.",
+        "INVALID_TARGET_MODE": "Elige un modo de objetivo válido.",
+        "INVALID_SAVE_OUTCOME": "Elige un resultado de salvación válido.",
+        "SAVE_NOTES_REQUIRED": "Añade indicaciones para esta salvación.",
+        "INVALID_ATTACK_MODE": "Elige un tipo de ataque válido.",
+        "ATTACK_MODE_REQUIRED": "Los efectos de ataque necesitan un tipo de ataque.",
+        "ATTACK_NOTES_REQUIRED": "Los ataques personalizados necesitan indicaciones.",
+        "EFFECT_REFERENCE_OR_NOTES_REQUIRED": "Los efectos con referencia necesitan una referencia de reglas o notas.",
+        "TOO_MANY_ACTIONS": "Este conjuro tiene demasiados efectos.",
+        "DUPLICATE_ACTION_ID": "Cada efecto del conjuro debe tener un ID único.",
+        "UNSUPPORTED_FORMULA_REFERENCE": "La fórmula usa una referencia de datos no compatible.",
+        "INVALID_LEVEL_SOURCE": "Elige una fuente de nivel de lanzador válida.",
+        "FIXED_LEVEL_REQUIRED": "Introduce un nivel de lanzador fijo.",
+        "INVALID_FIXED_LEVEL": "El nivel fijo debe ser un entero entre 1 y 100.",
+        "INVALID_CASTER_LEVEL": "El nivel de lanzador debe ser un entero entre 1 y 100.",
+        "ABILITY_MODIFIER_REQUIRED": "Esta fórmula necesita un modificador de característica, pero no hay ninguno disponible.",
+        "ITEM_NOT_FOUND": "El conjuro ya no está disponible.",
+        "NOT_AUTHORIZED": "No puedes usar este efecto del conjuro.",
+        "CAST_IN_PROGRESS": "Este conjuro ya se está lanzando.",
+        "SPELL_NOT_PREPARED": "Este conjuro no está memorizado.",
+        "MESSAGE_CREATE_FAILED": "No se pudo crear la tarjeta; el conjuro no se consumió.",
+        "STALE_PREPARATION": "Los conjuros memorizados cambiaron durante el lanzamiento.",
+        "CONSUMPTION_FAILED": "La tarjeta se creó, pero no se pudo consumir el conjuro.",
+        "ACTION_NOT_FOUND": "Este efecto ya no existe.",
+        "STALE_ACTION": "El efecto cambió después de publicar la tarjeta.",
+        "ACTION_IN_PROGRESS": "Este efecto ya se está resolviendo.",
+        "SINGLE_TARGET_REQUIRED": "Selecciona exactamente un objetivo.",
+        "TARGET_REQUIRED": "Selecciona al menos un objetivo.",
+        "NON_FINITE_ROLL": "La tirada no produjo un total finito.",
+        "INVALID_ROLL_FORMULA": "La fórmula de tirada es inválida.",
+        "GM_REQUIRED": "Solo un DJ puede aplicar daño o curación.",
+        "INVALID_MESSAGE_SCHEMA": "Esta tarjeta usa una versión de datos no compatible.",
+        "ACTION_NOT_APPLICABLE": "Este efecto no puede cambiar puntos de golpe.",
+        "ACTION_KIND_MISMATCH": "La aplicación solicitada no coincide con el efecto.",
+        "TARGET_NOT_IN_RESULT": "El objetivo no forma parte de este resultado.",
+        "APPLICATION_IN_PROGRESS": "Este resultado ya se está aplicando.",
+        "TARGET_NOT_FOUND": "El objetivo ya no está disponible.",
+        "TARGET_UPDATE_FAILED": "No se pudo actualizar el objetivo.",
+        "AUDIT_FAILED_ROLLED_BACK": "Falló la auditoría y se revirtió el cambio de puntos de golpe.",
+        "ROLLBACK_FAILED": "Fallaron la auditoría y la reversión. Revisa los puntos de golpe inmediatamente.",
+        "APPLICATION_FAILED": "No se pudo aplicar el daño o la curación."
+      }
+    },
     "NPCSheet": {
       "Main": {
         "Name": "Nombre",
@@ -208,6 +355,11 @@
         "Level": "Nivel",
         "Range": "Alcance",
         "Duration": "Duración",
+        "CasterLevelSource": "Fuente del nivel de lanzador",
+        "FixedCasterLevel": "Nivel de lanzador fijo",
+        "Actions": "Efectos del conjuro",
+        "EditActions": "Editar efectos del conjuro",
+        "NoActions": "Sin efectos del conjuro",
         "Tabs": {
           "Attributes": "Atributos",
           "Description": "Descripción"

--- a/module/actor/actor-sheet.mjs
+++ b/module/actor/actor-sheet.mjs
@@ -15,6 +15,7 @@ export class SwordsWizardryActorSheet extends HandlebarsApplicationMixin(ActorSh
       roll: this.#roll,
       saveRoll: this.#saveRoll,
       spellCast: this.#spellCast,
+      spellPost: this.#spellPost,
       spellPrepare: this.#spellPrepare
     },
     tag: 'form',
@@ -129,7 +130,6 @@ export class SwordsWizardryActorSheet extends HandlebarsApplicationMixin(ActorSh
     // TODO is this needed?
     // Add roll data for TinyMCE editors.
     context.rollData = this.actor.getRollData();
-    console.log(this._configureRenderParts());
     return context;
   }
 
@@ -148,7 +148,6 @@ export class SwordsWizardryActorSheet extends HandlebarsApplicationMixin(ActorSh
 
       for (let i of this.actor.items) {
         i.img = i.img || Item.DEFAULT_ICON;
-        if (!i.system.spellLevel) i.system.spellLevel = 1;
         switch (i.type) {
           case 'armor': context.armor.push(i); break;
           case 'feature': context.features.push(i); break;
@@ -194,7 +193,6 @@ export class SwordsWizardryActorSheet extends HandlebarsApplicationMixin(ActorSh
 
   static async #itemCreate(event, target) {
     const { type, spellLevel } = target.dataset;
-    console.log(spellLevel);
     const name = game.i18n.localize(`New.${type}`);
     const data = { name, type };
     if (spellLevel) data.system = { spellLevel };
@@ -259,31 +257,42 @@ export class SwordsWizardryActorSheet extends HandlebarsApplicationMixin(ActorSh
   static async #spellPrepare(event, target) {
     const { id } = target.dataset;
     const item = this.actor.items.get(id);
+    if (!item || !this.actor.isOwner) return;
     const { spellLevel } = item.system;
     const slots = this.actor.system.spellSlots[spellLevel];
-    if (slots.memorized.length < slots.max) {
-      slots.memorized.push(item._id);
-      slots.memorizedSpells = slots.memorizedSpells || [];
-      slots.memorizedSpells.push(item);
-    }
-    const spellSlots = {};
+    if (!slots || slots.memorized.length >= slots.max) return;
+    const memorized = [...slots.memorized, item.id];
     const key = `system.spellSlots.${spellLevel}.memorized`;
-    await this.actor.update({
-      [key]: slots.memorized
-    });
+    await this.actor.update({ [key]: memorized });
     this.actor.render();
   }
 
   static async #spellCast(event, target) {
     const { id } = target.dataset;
     const item = this.actor.items.get(id);
-    item.roll();
-    const { spellLevel } = item.system;
-    const slots = this.actor.system.spellSlots[spellLevel];
-    const mIndex = slots.memorized.indexOf(id);
-    if (mIndex > -1) slots.memorized.splice(mIndex, 1);
-    const sIndex = slots.memorizedSpells.indexOf(item);
-    if (sIndex > -1) slots.memorizedSpells.splice(sIndex, 1);
-    this.actor.render();
+    if (!item) return;
+    await runSpellAction(target, () => item.cast());
+  }
+
+  static async #spellPost(event, target) {
+    const { id } = target.dataset;
+    const item = this.actor.items.get(id);
+    if (!item) return;
+    await runSpellAction(target, () => item.post());
+  }
+}
+
+async function runSpellAction(target, operation) {
+  target.disabled = true;
+  try {
+    const result = await operation();
+    if (result?.status !== 'failure') return;
+    const key = `SWORDS_WIZARDRY.Spell.Validation.${result.code}`;
+    const localized = game.i18n.localize(key);
+    ui.notifications.warn(localized === key
+      ? game.i18n.localize('SWORDS_WIZARDRY.Spell.Validation.UNKNOWN')
+      : localized);
+  } finally {
+    target.disabled = false;
   }
 }

--- a/module/actor/spells.hbs
+++ b/module/actor/spells.hbs
@@ -13,26 +13,23 @@
           <li class='item grid grid-6col' data-item-id='{{spell._id}}'>
             <div class='item-name grid-span-5'>
               <div class='item-image'>
-                <a
-                  class='rollable'
-                  data-action='roll'
-                  data-id='{{item._id}}'
-                  data-roll-type='item'
-                >
-                  <img src='{{spell.img}}' title='{{spell.name}}' width='24' height='24'/>
-                </a>
+                <button type="button" class="rollable image-button" data-action="spellPost" data-id="{{spell._id}}" title="{{localize 'SWORDS_WIZARDRY.Spell.Actions.PostNamed' spell=spell.name}}">
+                  <img src='{{spell.img}}' alt='' width='24' height='24'/>
+                  <span class="sr-only">{{localize 'SWORDS_WIZARDRY.Spell.Actions.PostNamed' spell=spell.name}}</span>
+                </button>
               </div>
               <span class='item-name-span'>{{spell.name}}</span>
             </div>
             <div class='item-controls'>
-              <a
+              <button type="button"
                 class='item-control'
                 data-action="spellCast"
                 data-id="{{spell._id}}"
-                title='Cast'
+                title='{{localize "SWORDS_WIZARDRY.Spell.Actions.CastNamed" spell=spell.name}}'
               >
-                <i class='fas fa-wand-magic'></i>
-              </a>
+                <i class='fas fa-wand-magic' aria-hidden="true"></i>
+                <span class="sr-only">{{localize "SWORDS_WIZARDRY.Spell.Actions.CastNamed" spell=spell.name}}</span>
+              </button>
             </div>
           </li>
         {{/each}}
@@ -68,56 +65,61 @@
         {{localize 'SWORDS_WIZARDRY.CharacterSheet.Spells.SpellLVL' level=spellLevel}}
       </div>
       <div class='item-controls'>
-        <a
+        <button type="button"
           class='item-control item-create'
           title='{{localize "SWORDS_WIZARDRY.CharacterSheet.Spells.Table.Create" type='Spell'}}'
           data-action="itemCreate"
           data-type='spell'
           data-spell-level='{{spellLevel}}'
         >
-          <i class='fas fa-plus'></i>
-        </a>
+          <i class='fas fa-plus' aria-hidden="true"></i>
+          <span class="sr-only">{{localize "SWORDS_WIZARDRY.CharacterSheet.Spells.Table.Create" type='Spell'}}</span>
+        </button>
       </div>
     </li>
     {{#each spells as |item id|}}
     <li class='item grid grid-6col' data-item-id='{{item._id}}'>
       <div class='item-name flexrow grid-span-5'>
         <div class='item-image'>
-          <a
-            class='rollable'
-            data-action='roll'
+          <button type="button"
+            class='rollable image-button'
+            data-action='spellPost'
             data-id='{{item._id}}'
-            data-roll-type='item'
+            title="{{localize 'SWORDS_WIZARDRY.Spell.Actions.PostNamed' spell=item.name}}"
           >
-            <img src='{{item.img}}' title='{{item.name}}' width='24' height='24'/>
-          </a>
+            <img src='{{item.img}}' alt='' width='24' height='24'/>
+            <span class="sr-only">{{localize 'SWORDS_WIZARDRY.Spell.Actions.PostNamed' spell=item.name}}</span>
+          </button>
         </div>
         <span class='item-name-span'>{{item.name}}</span>
       </div>
       <div class='item-controls'>
-        <a
+        <button type="button"
           class='item-control'
           data-action="spellPrepare"
           data-id="{{item._id}}"
-          title='Memorize'
+          title='{{localize "SWORDS_WIZARDRY.Spell.Actions.PrepareNamed" spell=item.name}}'
         >
-          <i class='fas fa-brain'></i>
-        </a>
-        <a
+          <i class='fas fa-brain' aria-hidden="true"></i>
+          <span class="sr-only">{{localize "SWORDS_WIZARDRY.Spell.Actions.PrepareNamed" spell=item.name}}</span>
+        </button>
+        <button type="button"
           class='item-control item-edit'
           data-action='itemEdit'
           data-id='{{item._id}}'
           title='{{localize "SWORDS_WIZARDRY.CharacterSheet.Spells.Table.Update" type='spell'}}'
         >
-          <i class='fas fa-edit'></i>
-        </a>
-        <a
+          <i class='fas fa-edit' aria-hidden="true"></i>
+          <span class="sr-only">{{localize "SWORDS_WIZARDRY.CharacterSheet.Spells.Table.Update" type='spell'}}</span>
+        </button>
+        <button type="button"
           class='item-control item-delete'
           data-action='itemDelete'
           data-id='{{item._id}}'
           title='{{localize "SWORDS_WIZARDRY.CharacterSheet.Spells.Table.Delete" type='spell'}}'>
-          <i class='fas fa-trash'></i>
-        </a>
+          <i class='fas fa-trash' aria-hidden="true"></i>
+          <span class="sr-only">{{localize "SWORDS_WIZARDRY.CharacterSheet.Spells.Table.Delete" type='spell'}}</span>
+        </button>
       </div>
     </li>
     {{/each}}

--- a/module/item/item-model.mjs
+++ b/module/item/item-model.mjs
@@ -1,6 +1,16 @@
+import {
+  SPELL_ACTION_KINDS,
+  SPELL_ACTION_LIMITS,
+  SPELL_ATTACK_MODES,
+  SPELL_LEVEL_SOURCES,
+  SPELL_SAVE_OUTCOMES,
+  SPELL_TARGET_MODES
+} from '../spells/constants.mjs';
+import { normalizeCasting, normalizeSpellActions } from '../spells/domain.mjs';
+
 const { TypeDataModel } = foundry.abstract;
 const {
-  SchemaField, HTMLField, BooleanField, NumberField, StringField
+  ArrayField, SchemaField, HTMLField, BooleanField, NumberField, StringField
 } = foundry.data.fields;
 
 class BaseItemData extends TypeDataModel {
@@ -68,11 +78,89 @@ export class SpellData extends BaseItemData {
     return {
       ...base,
       spellLevel: new NumberField({
-        required: true, integer: true, initial: 1
+        required: true, integer: true, min: 1, max: 9, initial: 1
       }),
-      range: new StringField(),
-      duration: new StringField()
+      range: new StringField({ initial: '' }),
+      duration: new StringField({ initial: '' }),
+      casting: new SchemaField({
+        levelSource: new StringField({
+          required: true,
+          choices: SPELL_LEVEL_SOURCES,
+          initial: 'automatic'
+        }),
+        fixedLevel: new NumberField({
+          integer: true,
+          min: 1,
+          max: 100,
+          nullable: true,
+          initial: null
+        })
+      }),
+      actions: new ArrayField(new SchemaField({
+        id: new StringField({ required: true, maxLength: SPELL_ACTION_LIMITS.id }),
+        kind: new StringField({
+          required: true,
+          choices: SPELL_ACTION_KINDS,
+          initial: 'manual'
+        }),
+        label: new StringField({
+          required: true,
+          maxLength: SPELL_ACTION_LIMITS.label
+        }),
+        formula: new StringField({
+          initial: '',
+          maxLength: SPELL_ACTION_LIMITS.formula
+        }),
+        target: new SchemaField({
+          mode: new StringField({
+            required: true,
+            choices: SPELL_TARGET_MODES,
+            initial: 'none'
+          })
+        }),
+        save: new SchemaField({
+          outcome: new StringField({
+            required: true,
+            choices: SPELL_SAVE_OUTCOMES,
+            initial: 'none'
+          }),
+          notes: new StringField({
+            initial: '',
+            maxLength: SPELL_ACTION_LIMITS.notes
+          })
+        }),
+        attack: new SchemaField({
+          mode: new StringField({
+            required: true,
+            choices: SPELL_ATTACK_MODES,
+            initial: 'none'
+          }),
+          notes: new StringField({
+            initial: '',
+            maxLength: SPELL_ACTION_LIMITS.notes
+          })
+        }),
+        effect: new SchemaField({
+          reference: new StringField({
+            initial: '',
+            maxLength: SPELL_ACTION_LIMITS.effectReference
+          })
+        }),
+        notes: new StringField({
+          initial: '',
+          maxLength: SPELL_ACTION_LIMITS.notes
+        })
+      }), {
+        initial: [],
+        max: SPELL_ACTION_LIMITS.count
+      })
     };
+  }
+
+  static validateJoint(data) {
+    super.validateJoint(data);
+    normalizeCasting(data.casting ?? {});
+    normalizeSpellActions(data.actions ?? []);
   }
 }
 

--- a/module/item/item-sheet.hbs
+++ b/module/item/item-sheet.hbs
@@ -69,18 +69,62 @@
     <div class="grid grid-2col">
       <div class="resource">
         <label class="resource-label">{{localize "SWORDS_WIZARDRY.Item.Spell.Level"}}</label>
-        <input type="text" name="system.spellLevel" value="{{system.spellLevel}}" data-dtype="Text"/>
+        <input type="number" name="system.spellLevel" value="{{system.spellLevel}}" min="1" max="9" step="1" {{#unless editable}}disabled{{/unless}}/>
       </div>
       <div class="resource">
         <label class="resource-label">{{localize "SWORDS_WIZARDRY.Item.Spell.Range"}}</label>
-        <input type="text" name="system.range" value="{{system.range}}" data-dtype="Text"/>
+        <input type="text" name="system.range" value="{{system.range}}" {{#unless editable}}disabled{{/unless}}/>
       </div>
     </div>
     <div class="grid grid-1col">
       <div class="resource">
         <label class="resource-label">{{localize "SWORDS_WIZARDRY.Item.Spell.Duration"}}</label>
-        <input type="text" name="system.duration" value="{{system.duration}}" data-dtype="Text"/>
+        <input type="text" name="system.duration" value="{{system.duration}}" {{#unless editable}}disabled{{/unless}}/>
       </div>
+    </div>
+    <div class="grid grid-2col spell-casting-fields">
+      <div class="resource">
+        <label class="resource-label" for="{{rootId}}-caster-level-source">{{localize "SWORDS_WIZARDRY.Item.Spell.CasterLevelSource"}}</label>
+        <select id="{{rootId}}-caster-level-source" name="system.casting.levelSource" {{#unless editable}}disabled{{/unless}}>
+          {{#each casterLevelSources as |option|}}
+            <option value="{{option.value}}" {{#if (eq option.value ../system.casting.levelSource)}}selected{{/if}}>{{localize option.label}}</option>
+          {{/each}}
+        </select>
+      </div>
+      <div class="resource">
+        <label class="resource-label" for="{{rootId}}-fixed-caster-level">{{localize "SWORDS_WIZARDRY.Item.Spell.FixedCasterLevel"}}</label>
+        <input id="{{rootId}}-fixed-caster-level" type="number" name="system.casting.fixedLevel" value="{{system.casting.fixedLevel}}" min="1" max="100" step="1" {{#unless editable}}disabled{{/unless}}/>
+      </div>
+    </div>
+    <section class="spell-actions-summary" aria-labelledby="{{rootId}}-spell-actions-heading">
+      <div class="spell-actions-summary__header">
+        <h3 id="{{rootId}}-spell-actions-heading">{{localize "SWORDS_WIZARDRY.Item.Spell.Actions"}}</h3>
+        {{#if editable}}
+          <button type="button" data-action="editSpellActions">
+            <i class="fas fa-pen" aria-hidden="true"></i>
+            {{localize "SWORDS_WIZARDRY.Item.Spell.EditActions"}}
+          </button>
+        {{/if}}
+      </div>
+      <ol>
+        {{#each spellActions as |action|}}
+          <li><strong>{{action.label}}</strong> <span>({{action.kindLabel}})</span>{{#if action.formula}} <code>{{action.formula}}</code>{{/if}}</li>
+        {{else}}
+          <li class="spell-actions-summary__empty">{{localize "SWORDS_WIZARDRY.Item.Spell.NoActions"}}</li>
+        {{/each}}
+      </ol>
+    </section>
+    <div class="spell-sheet-actions">
+      <button type="button" data-action="spellPost">
+        <i class="fas fa-message" aria-hidden="true"></i>
+        {{localize "SWORDS_WIZARDRY.Spell.Actions.Post"}}
+      </button>
+      {{#if canCast}}
+        <button type="button" data-action="spellCast">
+          <i class="fas fa-wand-magic-sparkles" aria-hidden="true"></i>
+          {{localize "SWORDS_WIZARDRY.Spell.Actions.Cast"}}
+        </button>
+      {{/if}}
     </div>
     {{/if}}
     {{#if (eq item.type 'weapon')}}

--- a/module/item/item-sheet.mjs
+++ b/module/item/item-sheet.mjs
@@ -1,10 +1,16 @@
+import { SpellActionEditor } from '../spells/action-editor.mjs';
+import { SPELL_LEVEL_SOURCES } from '../spells/constants.mjs';
+
 const { HandlebarsApplicationMixin } = foundry.applications.api;
 const { ItemSheetV2 } = foundry.applications.sheets;
 
 export class SwordsWizardryItemSheet extends HandlebarsApplicationMixin(ItemSheetV2) {
   static DEFAULT_OPTIONS = {
     actions: {
-      editImage: this.#onEditImage
+      editImage: this.#onEditImage,
+      editSpellActions: this.#editSpellActions,
+      spellPost: this.#spellPost,
+      spellCast: this.#spellCast
     },
     tag: 'form',
     form: {
@@ -33,9 +39,23 @@ export class SwordsWizardryItemSheet extends HandlebarsApplicationMixin(ItemShee
   async _prepareContext(options) {
     const context = await super._prepareContext(options);
     context.item = this.item;
+    context.rootId = this.id;
     context.rollData = this.item.getRollData();
     context.system = this.item.system;
     context.flags = this.item.flags;
+    if (this.item.type === 'spell') {
+      context.spellActions = Array.from(this.item.system.actions ?? []).map((action) => ({
+        ...action,
+        kindLabel: game.i18n.localize(`SWORDS_WIZARDRY.Spell.ActionKinds.${action.kind}`)
+      }));
+      context.casterLevelSources = SPELL_LEVEL_SOURCES.map((value) => ({
+        value,
+        label: `SWORDS_WIZARDRY.Spell.CasterLevelSources.${value}`
+      }));
+      const actor = this.item.actor ?? this.item.parent;
+      const level = this.item.system.spellLevel;
+      context.canCast = actor?.system?.spellSlots?.[level]?.memorized?.includes(this.item.id) === true;
+    }
     return context;
   }
 
@@ -57,4 +77,33 @@ export class SwordsWizardryItemSheet extends HandlebarsApplicationMixin(ItemShee
     fp.render(true);
   }
 
+  static async #editSpellActions() {
+    if (!this.item.isOwner) return;
+    await new SpellActionEditor(this.item).render(true);
+  }
+
+  static async #spellPost(_event, target) {
+    await runSpellAction(target, () => this.item.post());
+  }
+
+  static async #spellCast(_event, target) {
+    await runSpellAction(target, () => this.item.cast());
+  }
+
+}
+
+async function runSpellAction(target, operation) {
+  target.disabled = true;
+  try {
+    const result = await operation();
+    if (result?.status === 'failure') {
+      const key = `SWORDS_WIZARDRY.Spell.Validation.${result.code}`;
+      const localized = game.i18n.localize(key);
+      ui.notifications.warn(localized === key
+        ? game.i18n.localize('SWORDS_WIZARDRY.Spell.Validation.UNKNOWN')
+        : localized);
+    }
+  } finally {
+    target.disabled = false;
+  }
 }

--- a/module/item/item.mjs
+++ b/module/item/item.mjs
@@ -1,4 +1,5 @@
 import { AttackRoll, FeatureRoll } from  '../rolls/rolls.mjs';
+import { captureTargetSnapshots } from '../spells/attack-plan.mjs';
 
 export class SwordsWizardryItem extends Item {
 
@@ -50,6 +51,7 @@ export class SwordsWizardryItem extends Item {
     if (this.actor) {
       rollData.actor = this.actor.getRollData();
       rollData.actor._id = this.actor._id;
+      rollData.targetSnapshots = captureTargetSnapshots(game.user.targets);
       if (game.settings.get('swords-wizardry', 'useAscendingAC')) {
         rollData.formula += ` + ${rollData.actor.tHAACB}`;
       }
@@ -71,7 +73,17 @@ export class SwordsWizardryItem extends Item {
     return rollData;
   }
 
-  async roll() {
+  async post(options = {}) {
+    if (this.type !== 'spell') return this.roll(options);
+    return game.swordswizardry.spells.post(this, options);
+  }
+
+  async cast(options = {}) {
+    if (this.type !== 'spell') return this.roll(options);
+    return game.swordswizardry.spells.cast(this, options);
+  }
+
+  async roll(options = {}) {
     const item = this;
     let rollData, roll;
     switch (this.type) {
@@ -88,19 +100,19 @@ export class SwordsWizardryItem extends Item {
           return roll;
         }
       case 'spell':
+        return this.post(options);
       case 'item':
       case 'armor':
         // TODO update this 
         const speaker = ChatMessage.getSpeaker({ actor: this.actor });
         const rollMode = game.settings.get('core', 'rollMode');
         const label = `[${item.type}] ${item.name}`;
-        ChatMessage.create({
+        return ChatMessage.create({
           speaker: speaker,
           rollMode: rollMode,
           flavor: label,
           content: item.system.description ?? '',
         });
-        break;
     }
   }
 }

--- a/module/rolls/attack-roll-sheet.hbs
+++ b/module/rolls/attack-roll-sheet.hbs
@@ -2,10 +2,10 @@
 <div class="swords-wizardry">
   <h3>{{localize "SWORDS_WIZARDRY.Chat.Rolled"}}: {{item.name}}</h3>
   {{#each hitTargets as |hit hid|}}
-  <span class="attack-hit">{{localize "SWORDS_WIZARDRY.Chat.Hit"}} {{hit.actor.name}}!</span>&nbsp;
+  <span class="attack-hit">{{localize "SWORDS_WIZARDRY.Chat.Hit"}} {{hit.name}}!</span>&nbsp;
   {{/each}}
   {{#each missedTargets as |miss hid|}}
-  <span class="attack-miss">{{localize "SWORDS_WIZARDRY.Chat.Missed"}} {{miss.actor.name}}</span>&nbsp;
+  <span class="attack-miss">{{localize "SWORDS_WIZARDRY.Chat.Missed"}} {{miss.name}}</span>&nbsp;
   {{/each}}
   <a class="inline-result"><span>{{{roll}}}</span></a>
   <button class="damage-roll-button" data-actor-id="{{actor._id}}" data-item-id="{{item._id}}">

--- a/module/rolls/rolls.mjs
+++ b/module/rolls/rolls.mjs
@@ -1,5 +1,6 @@
 import { SwordsWizardryChatMessage } from '../helpers/overrides.mjs';
 import { rpc } from '../helpers/rpc.mjs';
+import { evaluateAttackPlan } from '../spells/attack-plan.mjs';
 
 const { renderTemplate } = foundry.applications.handlebars;
 
@@ -13,24 +14,20 @@ export class AttackRoll extends Roll {
 
   async evaluate() {
     const result = await super.evaluate();
-    // TODO move game.user.targets to up the chain and pass it in for more generic attacks?
-    game.user.targets.forEach((target) => {
-      let hit = false;
-      if (game.settings.get('swords-wizardry', 'useAscendingAC')) {
-        // Attack bonus is added to the roll formula by the item.
-        const targetAAC = target.actor.system.aac.value;
-        if (result.total >= targetAAC) hit = true;
-      } else {
-        const targetAC = target.actor.system.ac.value;
-        const targetNumber = this.data.actor.tHAC0 - targetAC;
-        if (result.total >= targetNumber) hit = true;
-      }
-      if (hit) {
-        this.hitTargets.push(target);
-      } else {
-        this.missedTargets.push(target);
-      }
+    const targetSnapshots = this.data.targetSnapshots ?? [];
+    const outcomes = evaluateAttackPlan({
+      total: result.total,
+      mode: this.data.missile ? 'missile' : 'melee',
+      useAscendingAC: game.settings.get('swords-wizardry', 'useAscendingAC'),
+      attacker: this.data.actor,
+      targets: targetSnapshots
     });
+    this.hitTargets = targetSnapshots.filter((target) => (
+      outcomes.find((outcome) => outcome.uuid === target.uuid)?.outcome === 'hit'
+    ));
+    this.missedTargets = targetSnapshots.filter((target) => (
+      outcomes.find((outcome) => outcome.uuid === target.uuid)?.outcome === 'miss'
+    ));
     return result;
   }
 

--- a/module/scss/components/_apps.scss
+++ b/module/scss/components/_apps.scss
@@ -1,3 +1,5 @@
+@use '../utils/typography' as *;
+
 .combat-hud-name {
   font-family: $font-primary;
 }

--- a/module/scss/components/_items.scss
+++ b/module/scss/components/_items.scss
@@ -1,3 +1,6 @@
+@use '../utils/colors' as *;
+@use '../utils/variables' as *;
+
 // Section Header
 .items-header {
   height: 28px;

--- a/module/scss/components/_messages.scss
+++ b/module/scss/components/_messages.scss
@@ -1,3 +1,5 @@
+@use '../utils/typography' as *;
+
 .damage-roll-button {
   font-family: $font-primary;
   width: 100%;

--- a/module/scss/components/_spells.scss
+++ b/module/scss/components/_spells.scss
@@ -1,0 +1,296 @@
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid var(--color-shadow-primary, #7a4d00);
+  outline-offset: 2px;
+}
+
+.image-button {
+  width: 26px;
+  height: 26px;
+  min-height: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+
+  img {
+    display: block;
+  }
+}
+
+.spell-casting-fields {
+  align-items: end;
+}
+
+.spell-actions-summary {
+  margin-block: 0.5rem;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+
+    h3 {
+      margin: 0;
+    }
+
+    button {
+      width: auto;
+      white-space: nowrap;
+    }
+  }
+
+  ol {
+    margin-block: 0.4rem;
+    padding-inline-start: 1.5rem;
+  }
+
+  code {
+    display: inline-block;
+    overflow-wrap: anywhere;
+  }
+
+  &__empty {
+    font-style: italic;
+  }
+}
+
+.spell-sheet-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-block: 0.5rem;
+
+  button {
+    flex: 1;
+  }
+}
+
+.spell-action-editor {
+  &__body {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    height: 100%;
+  }
+
+  &__toolbar,
+  &__footer,
+  &__action > header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+  }
+
+  &__toolbar button,
+  &__footer button,
+  &__order-controls button {
+    width: auto;
+  }
+
+  &__error,
+  .spell-card__warning {
+    border: 1px solid var(--color-level-error, #a00000);
+    padding: 0.5rem;
+  }
+
+  &__list {
+    flex: 1;
+    overflow: auto;
+    margin: 0.5rem 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  &__action {
+    border: 1px solid var(--color-border-light-primary, #777);
+    border-radius: 4px;
+    padding: 0.6rem;
+    margin-block-end: 0.6rem;
+  }
+
+  &__action h3 {
+    margin: 0;
+  }
+
+  &__order-controls {
+    display: flex;
+    gap: 0.25rem;
+  }
+
+  &__grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.5rem;
+    margin-block-start: 0.5rem;
+
+    label {
+      display: flex;
+      flex-direction: column;
+      gap: 0.2rem;
+      min-width: 0;
+    }
+
+    [hidden] {
+      display: none;
+    }
+
+    .grid-span-2 {
+      grid-column: 1 / -1;
+    }
+
+    textarea {
+      min-height: 3.5rem;
+      resize: vertical;
+    }
+  }
+}
+
+.spell-card {
+  &__header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+
+    img {
+      flex: 0 0 auto;
+      object-fit: cover;
+    }
+
+    h3,
+    p {
+      margin: 0;
+      overflow-wrap: anywhere;
+    }
+  }
+
+  &__metadata {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.25rem 0.75rem;
+    margin-block: 0.6rem;
+
+    div {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 0.35rem;
+      min-width: 0;
+    }
+
+    dt {
+      font-weight: 400;
+    }
+
+    dd {
+      margin: 0;
+      overflow-wrap: anywhere;
+    }
+  }
+
+  &__description,
+  &__actions {
+    margin-block-start: 0.6rem;
+  }
+
+  &__action-list {
+    display: grid;
+    gap: 0.35rem;
+
+    button {
+      display: flex;
+      justify-content: space-between;
+      gap: 0.5rem;
+      min-width: 0;
+    }
+
+    code {
+      overflow-wrap: anywhere;
+    }
+
+    .hint {
+      margin: -0.2rem 0 0.25rem;
+    }
+  }
+
+  &__warning {
+    border-inline-start: 4px solid var(--color-level-warning, #9a6700);
+    padding: 0.4rem 0.6rem;
+  }
+}
+
+.spell-result {
+  &__roll {
+    margin-block: 0.5rem;
+  }
+
+  &__targets ol {
+    padding-inline-start: 1.5rem;
+  }
+
+  &__targets.damage-targets ol {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  &__target {
+    margin-block: 0.4rem;
+  }
+
+  &__target-name {
+    font-weight: 700;
+  }
+
+  &__target-status,
+  &__application-status {
+    display: block;
+  }
+
+  &__application-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    margin-block-start: 0.25rem;
+
+    button {
+      flex: 1 1 7rem;
+    }
+  }
+
+  &__application-controls.damage-buttons {
+    flex-wrap: nowrap;
+    gap: 4px;
+    margin-top: 4px;
+
+    button {
+      flex: 1;
+      min-width: 0;
+      font-size: 11px;
+    }
+  }
+}
+
+@media (max-width: 520px) {
+  .spell-action-editor__grid,
+  .spell-card__metadata {
+    grid-template-columns: 1fr;
+  }
+
+  .spell-action-editor__grid .grid-span-2 {
+    grid-column: auto;
+  }
+}

--- a/module/scss/global/_window.scss
+++ b/module/scss/global/_window.scss
@@ -1,3 +1,5 @@
+@use '../utils/typography' as *;
+
 body {
   font-family: $font-primary;
   font-size: 10pt;

--- a/module/scss/swords-wizardry.scss
+++ b/module/scss/swords-wizardry.scss
@@ -1,27 +1,44 @@
+@use 'sass:meta';
+@use 'utils/typography';
+
 // Add custom fonts by visiting and search https://fonts.google.com
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap');
 
-// Import utilities.
-@import 'utils/typography';
-@import 'utils/colors';
-@import 'utils/mixins';
-@import 'utils/variables';
-
 /* Global styles */
-@import 'global/window';
-@import 'global/grid';
-@import 'global/flex';
-@import 'global/border';
+@include meta.load-css('global/window');
+@include meta.load-css('global/grid');
+@include meta.load-css('global/flex');
+@include meta.load-css('global/border');
 
 /* Styles limited to swords-wizardry sheets */
 .swords-wizardry {
   .window-content {
     overflow: scroll;
   }
-  @import 'components/apps';
-  @import 'components/effects';
-  @import 'components/forms';
-  @import 'components/items';
-  @import 'components/messages';
-  @import 'components/resource';
+  @include meta.load-css('components/apps');
+  @include meta.load-css('components/effects');
+  @include meta.load-css('components/forms');
+  @include meta.load-css('components/items');
+  @include meta.load-css('components/messages');
+  @include meta.load-css('components/resource');
+  @include meta.load-css('components/spells');
+}
+
+// Spell chat cards share the system class on their root element, so this reset
+// must use a compound selector rather than the sheet-oriented descendant scope.
+.swords-wizardry.spell-card {
+  &,
+  h3,
+  h4,
+  p,
+  dt,
+  dd,
+  strong {
+    color: inherit;
+    text-shadow: none;
+  }
+
+  button {
+    text-shadow: none;
+  }
 }

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -12,9 +12,9 @@ export function registerSystemSettings() {
     default: false
   });
 
-  // DM must apply damage
+  // DM must apply damage / healing
   game.settings.register("swords-wizardry", "dmAppliesDamage", {
-    name: "DM must apply damage",
+    name: "DM must apply damage / healing",
     scope: "world",
     config: true,
     type: Boolean,

--- a/module/spells/action-editor.mjs
+++ b/module/spells/action-editor.mjs
@@ -1,0 +1,244 @@
+import {
+  SPELL_ACTION_KINDS,
+  SPELL_ACTION_LIMITS,
+  SPELL_ATTACK_MODES,
+  SPELL_SAVE_OUTCOMES,
+  SPELL_TARGET_MODES
+} from './constants.mjs';
+import { SpellValidationError, normalizeSpellActions } from './domain.mjs';
+import {
+  actionsFromFormData,
+  actionsFromFormElements,
+  effectEditorVisibility,
+  moveAction
+} from './editor-state.mjs';
+
+const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
+
+export class SpellActionEditor extends HandlebarsApplicationMixin(ApplicationV2) {
+  static DEFAULT_OPTIONS = {
+    id: 'swords-wizardry-spell-action-editor-{id}',
+    tag: 'form',
+    classes: ['swords-wizardry', 'spell-action-editor'],
+    actions: {
+      addAction: this.#addAction,
+      removeAction: this.#removeAction,
+      moveActionUp: this.#moveActionUp,
+      moveActionDown: this.#moveActionDown
+    },
+    form: {
+      handler: this.#save,
+      closeOnSubmit: false,
+      submitOnChange: false
+    },
+    position: {
+      width: 720,
+      height: 720
+    },
+    window: {
+      icon: 'fas fa-wand-magic-sparkles',
+      resizable: true
+    }
+  };
+
+  static PARTS = {
+    form: {
+      template: `systems/swords-wizardry/module/templates/spells/action-editor.hbs`,
+      scrollable: ['.spell-action-editor__list']
+    }
+  };
+
+  constructor(item, options = {}) {
+    super({ ...options, id: `swords-wizardry-spell-action-editor-${item.id}` });
+    this.item = item;
+    this.draft = normalizeSpellActions(item.system?.actions ?? [], {
+      generateId: () => foundry.utils.randomID(16)
+    });
+    this.validationError = '';
+    this.pendingFocusIndex = null;
+    this.savedScrollTop = 0;
+  }
+
+  get title() {
+    return game.i18n.format('SWORDS_WIZARDRY.Spell.Editor.Title', {
+      spell: this.item.name
+    });
+  }
+
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+    return {
+      ...context,
+      item: this.item,
+      editable: this.item.isOwner === true,
+      actions: this.draft.map((action, index) => ({
+        ...action,
+        number: index + 1,
+        visibility: effectEditorVisibility(action.kind, {
+          saveOutcome: action.save.outcome,
+          attackMode: action.attack.mode
+        })
+      })),
+      actionKinds: choiceList(SPELL_ACTION_KINDS, 'ActionKinds'),
+      targetModes: choiceList(SPELL_TARGET_MODES, 'TargetModes'),
+      saveOutcomes: choiceList(SPELL_SAVE_OUTCOMES, 'SaveOutcomes'),
+      attackModes: choiceList(SPELL_ATTACK_MODES, 'AttackModes'),
+      canAdd: this.draft.length < SPELL_ACTION_LIMITS.count,
+      validationError: this.validationError,
+      limits: SPELL_ACTION_LIMITS
+    };
+  }
+
+  _onRender(context, options) {
+    super._onRender(context, options);
+    for (const row of this.element.querySelectorAll('[data-action-index]')) {
+      const kind = row.querySelector('[data-effect-kind]');
+      const save = row.querySelector('[data-effect-save]');
+      const attack = row.querySelector('[data-effect-attack]');
+      kind?.addEventListener('change', () => this.#syncEffectFields(row, { resetIrrelevant: true }));
+      save?.addEventListener('change', () => this.#syncEffectFields(row));
+      attack?.addEventListener('change', () => this.#syncEffectFields(row));
+      this.#syncEffectFields(row);
+    }
+    const list = this.element.querySelector('.spell-action-editor__list');
+    if (list) list.scrollTop = this.savedScrollTop;
+    if (this.pendingFocusIndex != null) {
+      const focusTarget = this.element.querySelector(
+        `[data-action-index="${this.pendingFocusIndex}"] input[name$=".label"]`
+      );
+      focusTarget?.focus();
+      this.pendingFocusIndex = null;
+    }
+  }
+
+  #syncEffectFields(row, { resetIrrelevant = false } = {}) {
+    const kind = row.querySelector('[data-effect-kind]')?.value ?? 'manual';
+    const save = row.querySelector('[data-effect-save]');
+    const attack = row.querySelector('[data-effect-attack]');
+    const visibility = effectEditorVisibility(kind, {
+      saveOutcome: save?.value,
+      attackMode: attack?.value
+    });
+
+    if (resetIrrelevant) {
+      if (!visibility.formula) setValue(row, '[data-effect-input="formula"]', '');
+      if (!visibility.save) {
+        setValue(row, '[data-effect-save]', 'none');
+        setValue(row, '[data-effect-input="save-notes"]', '');
+      }
+      if (!visibility.attack) {
+        setValue(row, '[data-effect-attack]', 'none');
+        setValue(row, '[data-effect-input="attack-notes"]', '');
+      }
+      if (!visibility.reference) setValue(row, '[data-effect-input="reference"]', '');
+      if (!visibility.notes) setValue(row, '[data-effect-input="notes"]', '');
+    }
+
+    const currentVisibility = effectEditorVisibility(kind, {
+      saveOutcome: row.querySelector('[data-effect-save]')?.value,
+      attackMode: row.querySelector('[data-effect-attack]')?.value
+    });
+    for (const [field, visible] of Object.entries(currentVisibility)) {
+      const container = row.querySelector(`[data-effect-field="${toKebabCase(field)}"]`);
+      if (container) container.hidden = !visible;
+    }
+  }
+
+  captureDraft() {
+    const list = this.element?.querySelector('.spell-action-editor__list');
+    if (list) this.savedScrollTop = list.scrollTop;
+    if (!this.form) return;
+    this.draft = actionsFromFormElements(this.form, this.draft.length);
+  }
+
+  static async #addAction() {
+    this.captureDraft();
+    if (this.draft.length >= SPELL_ACTION_LIMITS.count) return;
+    this.draft.push({
+      id: foundry.utils.randomID(16),
+      kind: 'manual',
+      label: game.i18n.localize('SWORDS_WIZARDRY.Spell.Editor.NewAction'),
+      formula: '',
+      target: { mode: 'none' },
+      save: { outcome: 'none', notes: '' },
+      attack: { mode: 'none', notes: '' },
+      effect: { reference: '' },
+      notes: ''
+    });
+    this.validationError = '';
+    this.pendingFocusIndex = this.draft.length - 1;
+    await this.render();
+  }
+
+  static async #removeAction(_event, target) {
+    this.captureDraft();
+    const index = Number(target.dataset.index);
+    if (!Number.isInteger(index) || index < 0 || index >= this.draft.length) return;
+    this.draft.splice(index, 1);
+    this.validationError = '';
+    this.pendingFocusIndex = Math.min(index, this.draft.length - 1);
+    await this.render();
+  }
+
+  static async #moveActionUp(_event, target) {
+    await move(this, Number(target.dataset.index), -1);
+  }
+
+  static async #moveActionDown(_event, target) {
+    await move(this, Number(target.dataset.index), 1);
+  }
+
+  static async #save(event, _form, formData) {
+    event.preventDefault();
+    if (!this.item.isOwner) return;
+    let submittedActions = this.draft;
+    try {
+      const expandedFormData = foundry.utils.expandObject(formData.object);
+      submittedActions = actionsFromFormData(expandedFormData.actions);
+      const actions = normalizeSpellActions(submittedActions, {
+        generateId: () => foundry.utils.randomID(16)
+      });
+      await this.item.update({ 'system.actions': actions });
+      this.draft = actions;
+      this.validationError = '';
+      await this.close();
+    } catch (error) {
+      this.draft = submittedActions;
+      this.validationError = localizeValidationError(error);
+      await this.render();
+    }
+  }
+}
+
+async function move(editor, index, direction) {
+  editor.captureDraft();
+  editor.draft = moveAction(editor.draft, index, direction);
+  editor.validationError = '';
+  editor.pendingFocusIndex = Math.max(0, Math.min(index + direction, editor.draft.length - 1));
+  await editor.render();
+}
+
+function choiceList(values, group) {
+  return values.map((value) => ({
+    value,
+    label: `SWORDS_WIZARDRY.Spell.${group}.${value}`
+  }));
+}
+
+function localizeValidationError(error) {
+  const code = error instanceof SpellValidationError ? error.code : 'UNKNOWN';
+  const key = `SWORDS_WIZARDRY.Spell.Validation.${code}`;
+  const localized = game.i18n.localize(key);
+  return localized === key
+    ? game.i18n.localize('SWORDS_WIZARDRY.Spell.Validation.UNKNOWN')
+    : localized;
+}
+
+function setValue(root, selector, value) {
+  const control = root.querySelector(selector);
+  if (control) control.value = value;
+}
+
+function toKebabCase(value) {
+  return value.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`);
+}

--- a/module/spells/application.mjs
+++ b/module/spells/application.mjs
@@ -1,0 +1,264 @@
+import {
+  SpellValidationError,
+  applyHitPointChange,
+  fingerprintAction,
+  normalizeSpellAction,
+  validateApplicationRequest
+} from './domain.mjs';
+import {
+  SPELL_APPLICATION_OPERATION,
+  SPELL_APPLICATION_SCHEMA_VERSION,
+  SPELL_FLAG_KEY,
+  SPELL_MESSAGE_SCHEMA_VERSION,
+  SYSTEM_ID
+} from './constants.mjs';
+
+export class SpellApplicationService {
+  #deps;
+  #locks = new Set();
+
+  constructor(dependencies) {
+    if (typeof dependencies?.resolveUuid !== 'function') {
+      throw new TypeError('SpellApplicationService requires resolveUuid.');
+    }
+    if (typeof dependencies?.getCurrentUser !== 'function') {
+      throw new TypeError('SpellApplicationService requires getCurrentUser.');
+    }
+    if (typeof dependencies?.getUserById !== 'function') {
+      throw new TypeError('SpellApplicationService requires getUserById.');
+    }
+    this.#deps = dependencies;
+  }
+
+  async applyAutomatically(messageOrUuid, options = {}) {
+    const currentUser = this.#deps.getCurrentUser();
+    if (!currentUser?.isGM) return failure('GM_REQUIRED');
+
+    try {
+      const message = typeof messageOrUuid === 'string'
+        ? await this.#deps.resolveUuid(messageOrUuid)
+        : messageOrUuid;
+      if (!message) return failure('MESSAGE_NOT_FOUND');
+
+      const flags = message.getFlag?.(SYSTEM_ID, SPELL_FLAG_KEY)
+        ?? message.flags?.[SYSTEM_ID]?.[SPELL_FLAG_KEY];
+      if (
+        flags?.schemaVersion !== SPELL_MESSAGE_SCHEMA_VERSION
+        || flags?.messageKind !== 'spell-result'
+        || !['damage', 'healing'].includes(flags?.action?.kind)
+      ) {
+        return failure('ACTION_NOT_APPLICABLE');
+      }
+
+      const requestingUserId = String(options.requestingUserId ?? '');
+      const requestingUser = this.#deps.getUserById(requestingUserId);
+      const authorId = message.author?.id ?? message.user?.id ?? message.user;
+      if (!requestingUser || authorId !== requestingUserId) {
+        return failure('AUTO_APPLICATION_NOT_AUTHORIZED');
+      }
+
+      const sourceMessage = await this.#deps.resolveUuid(flags.sourceMessageUuid);
+      const sourceFlags = sourceMessage?.getFlag?.(SYSTEM_ID, SPELL_FLAG_KEY)
+        ?? sourceMessage?.flags?.[SYSTEM_ID]?.[SPELL_FLAG_KEY];
+      if (
+        sourceFlags?.schemaVersion !== SPELL_MESSAGE_SCHEMA_VERSION
+        || sourceFlags?.messageKind !== 'spell-card'
+        || sourceFlags.sourceItemUuid !== flags.sourceItemUuid
+      ) {
+        return failure('AUTO_APPLICATION_SOURCE_INVALID');
+      }
+
+      const sourceStoredAction = sourceFlags.actions?.find(
+        (entry) => entry.id === flags.action.id
+      );
+      if (!sourceStoredAction) return failure('AUTO_APPLICATION_SOURCE_INVALID');
+      const { fingerprint: sourceFingerprint, ...sourceActionData } = sourceStoredAction;
+      const sourceAction = normalizeSpellAction(sourceActionData);
+      if (
+        sourceFingerprint !== fingerprintAction(sourceAction)
+        || sourceFingerprint !== flags.action.fingerprint
+      ) {
+        return failure('STALE_ACTION');
+      }
+
+      const sourceItem = await this.#deps.resolveUuid(flags.sourceItemUuid);
+      const ownsSource = requestingUser.isGM
+        || sourceItem?.testUserPermission?.(requestingUser, 'OWNER') === true;
+      if (sourceItem?.type !== 'spell' || !ownsSource) {
+        return failure('AUTO_APPLICATION_NOT_AUTHORIZED');
+      }
+
+      return this.apply(message, {
+        targetUuid: options.targetUuid,
+        kind: flags.action.kind,
+        multiplier: 1
+      });
+    } catch (error) {
+      if (error instanceof SpellValidationError) {
+        return failure(error.code, { error, details: error.details });
+      }
+      return failure('APPLICATION_FAILED', { error });
+    }
+  }
+
+  async apply(messageOrUuid, options = {}) {
+    const user = this.#deps.getCurrentUser();
+    if (!user?.isGM) return failure('GM_REQUIRED');
+
+    let message;
+    try {
+      message = typeof messageOrUuid === 'string'
+        ? await this.#deps.resolveUuid(messageOrUuid)
+        : messageOrUuid;
+      if (!message) return failure('MESSAGE_NOT_FOUND');
+
+      const flags = structuredCopy(
+        message.getFlag?.(SYSTEM_ID, SPELL_FLAG_KEY)
+        ?? message.flags?.[SYSTEM_ID]?.[SPELL_FLAG_KEY]
+        ?? {}
+      );
+      if (
+        flags.schemaVersion !== SPELL_MESSAGE_SCHEMA_VERSION
+        || flags.messageKind !== 'spell-result'
+      ) {
+        return failure('INVALID_MESSAGE_SCHEMA');
+      }
+
+      const { fingerprint: storedFingerprint, ...actionSource } = flags.action ?? {};
+      const action = normalizeSpellAction(actionSource);
+      if (storedFingerprint !== fingerprintAction(action)) return failure('STALE_ACTION');
+      if (!['damage', 'healing'].includes(action.kind)) return failure('ACTION_NOT_APPLICABLE');
+      if (options.kind !== action.kind) return failure('ACTION_KIND_MISMATCH');
+
+      const targetUuid = String(options.targetUuid ?? '');
+      if (!flags.targetUuids?.includes(targetUuid)) return failure('TARGET_NOT_IN_RESULT');
+      const applicationId = createApplicationId({
+        messageUuid: message.uuid,
+        actionId: action.id,
+        targetUuid
+      });
+      const applicationEntries = flags.application?.entries ?? {};
+      const existing = applicationEntries[applicationId];
+      if (existing && isApplicationEntryForMessage(applicationId, existing, message.uuid)) {
+        return { status: 'duplicate', application: existing };
+      }
+      if (this.#locks.has(applicationId)) return failure('APPLICATION_IN_PROGRESS');
+      this.#locks.add(applicationId);
+
+      try {
+        const amount = Number(flags.result?.total);
+        const request = validateApplicationRequest({
+          schemaVersion: SPELL_APPLICATION_SCHEMA_VERSION,
+          requestId: applicationId,
+          operation: SPELL_APPLICATION_OPERATION,
+          messageUuid: message.uuid,
+          actionId: action.id,
+          actionFingerprint: storedFingerprint,
+          targetUuid,
+          kind: action.kind,
+          amount,
+          multiplier: Number(options.multiplier ?? 1)
+        });
+
+        const target = await this.#deps.resolveUuid(request.targetUuid);
+        const actor = target?.actor ?? (target?.documentName === 'Actor' ? target : null);
+        if (!actor) return failure('TARGET_NOT_FOUND');
+
+        const change = applyHitPointChange({
+          kind: request.kind,
+          current: actor.system?.hp?.value,
+          maximum: actor.system?.hp?.max,
+          amount: request.amount,
+          multiplier: request.multiplier
+        });
+        const entry = {
+          applicationId,
+          requestId: request.requestId,
+          status: 'applied',
+          actionId: action.id,
+          actionFingerprint: storedFingerprint,
+          targetUuid,
+          actorUuid: actor.uuid ?? null,
+          kind: request.kind,
+          multiplier: request.multiplier,
+          requestedAmount: change.requestedAmount,
+          appliedAmount: change.appliedAmount,
+          oldHP: change.oldHP,
+          newHP: change.newHP,
+          appliedBy: user.id,
+          appliedAt: this.#deps.now?.() ?? Date.now()
+        };
+
+        try {
+          await actor.update({ 'system.hp.value': change.newHP });
+        } catch (error) {
+          return failure('TARGET_UPDATE_FAILED', { error });
+        }
+
+        const entriesPath = `flags.${SYSTEM_ID}.${SPELL_FLAG_KEY}.application.entries`;
+        const auditUpdate = { [`${entriesPath}.${applicationId}`]: entry };
+        for (const [entryId, application] of Object.entries(applicationEntries)) {
+          if (!isApplicationEntryForMessage(entryId, application, message.uuid)) {
+            auditUpdate[`${entriesPath}.-=${entryId}`] = null;
+          }
+        }
+        try {
+          await message.update(auditUpdate);
+        } catch (auditError) {
+          try {
+            await actor.update({ 'system.hp.value': change.oldHP });
+          } catch (rollbackError) {
+            return {
+              status: 'unsafe',
+              code: 'ROLLBACK_FAILED',
+              change,
+              auditError,
+              rollbackError
+            };
+          }
+          return failure('AUDIT_FAILED_ROLLED_BACK', { change, error: auditError });
+        }
+
+        return { status: 'success', application: entry, change };
+      } finally {
+        this.#locks.delete(applicationId);
+      }
+    } catch (error) {
+      if (error instanceof SpellValidationError) {
+        return failure(error.code, { error, details: error.details });
+      }
+      return failure('APPLICATION_FAILED', { error });
+    }
+  }
+}
+
+export function createFoundrySpellApplicationService() {
+  const resolveUuid = foundry.utils.fromUuid ?? globalThis.fromUuid;
+  return new SpellApplicationService({
+    resolveUuid: (uuid) => resolveUuid(uuid),
+    getCurrentUser: () => game.user,
+    getUserById: (id) => game.users.get(id),
+    now: () => Date.now()
+  });
+}
+
+export function createApplicationId({ messageUuid, actionId, targetUuid }) {
+  return `apply-${fingerprintAction({ messageUuid, actionId, targetUuid })}`;
+}
+
+export function isApplicationEntryForMessage(applicationId, entry, messageUuid) {
+  if (!entry || typeof entry !== 'object') return false;
+  return applicationId === createApplicationId({
+    messageUuid,
+    actionId: entry.actionId,
+    targetUuid: entry.targetUuid
+  });
+}
+
+function failure(code, extra = {}) {
+  return { status: 'failure', code, ...extra };
+}
+
+function structuredCopy(value) {
+  return JSON.parse(JSON.stringify(value));
+}

--- a/module/spells/attack-plan.mjs
+++ b/module/spells/attack-plan.mjs
@@ -1,0 +1,36 @@
+export function evaluateAttackPlan({
+  total,
+  mode,
+  useAscendingAC,
+  attacker,
+  targets = []
+}) {
+  if (!Number.isFinite(Number(total))) throw new TypeError('Attack total must be finite.');
+  return targets.map((target) => {
+    if (target.status === 'missing') return { uuid: target.uuid, outcome: 'missing' };
+    if (mode === 'custom') return { uuid: target.uuid, outcome: 'manual' };
+    const targetNumber = useAscendingAC
+      ? Number(target.aac)
+      : Number(attacker?.tHAC0) - Number(target.ac);
+    if (!Number.isFinite(targetNumber)) return { uuid: target.uuid, outcome: 'manual' };
+    return {
+      uuid: target.uuid,
+      outcome: Number(total) >= targetNumber ? 'hit' : 'miss',
+      targetNumber
+    };
+  });
+}
+export function captureTargetSnapshots(targets = []) {
+  return Array.from(targets).map((target) => {
+    const document = target.document ?? target;
+    const actor = target.actor ?? document.actor ?? null;
+    return {
+      uuid: document.uuid ?? target.uuid ?? null,
+      actorUuid: actor?.uuid ?? null,
+      name: target.name ?? document.name ?? actor?.name ?? '',
+      status: actor ? 'resolved' : 'missing',
+      ac: actor?.system?.ac?.value ?? null,
+      aac: actor?.system?.aac?.value ?? null
+    };
+  }).filter((target) => target.uuid);
+}

--- a/module/spells/chat-controller.mjs
+++ b/module/spells/chat-controller.mjs
@@ -1,0 +1,177 @@
+import { SPELL_FLAG_KEY, SYSTEM_ID } from './constants.mjs';
+import { isApplicationEntryForMessage } from './application.mjs';
+
+export class SpellChatController {
+  #deps;
+  #renderHookId = null;
+  #createHookId = null;
+  #renderHandler;
+  #createHandler;
+
+  constructor(dependencies) {
+    this.#deps = {
+      getActiveGM: () => null,
+      dmAppliesDamage: () => true,
+      ...dependencies
+    };
+    this.#renderHandler = (message, html) => this.#onRender(message, html);
+    this.#createHandler = (message, _options, userId) => (
+      this.#onCreate(message, userId).catch((error) => {
+        console.error('Swords & Wizardry | Automatic spell application failed.', error);
+      })
+    );
+  }
+
+  start() {
+    if (this.#renderHookId != null || this.#createHookId != null) return;
+    this.#renderHookId = this.#deps.hooks.on(
+      'renderChatMessageHTML',
+      this.#renderHandler
+    );
+    this.#createHookId = this.#deps.hooks.on('createChatMessage', this.#createHandler);
+  }
+
+  stop() {
+    if (this.#renderHookId != null) {
+      this.#deps.hooks.off('renderChatMessageHTML', this.#renderHookId);
+      this.#renderHookId = null;
+    }
+    if (this.#createHookId != null) {
+      this.#deps.hooks.off('createChatMessage', this.#createHookId);
+      this.#createHookId = null;
+    }
+  }
+
+  async #onCreate(message, requestingUserId) {
+    if (this.#deps.dmAppliesDamage()) return;
+
+    const currentUser = this.#deps.getCurrentUser();
+    const activeGM = this.#deps.getActiveGM();
+    if (!currentUser?.isGM || activeGM?.id !== currentUser.id) return;
+
+    const spell = message.getFlag?.(SYSTEM_ID, SPELL_FLAG_KEY)
+      ?? message.flags?.[SYSTEM_ID]?.[SPELL_FLAG_KEY];
+    if (
+      spell?.messageKind !== 'spell-result'
+      || !['damage', 'healing'].includes(spell.action?.kind)
+    ) return;
+
+    const failures = [];
+    for (const targetUuid of spell.targetUuids ?? []) {
+      const result = await this.#deps.applicationService.applyAutomatically(message, {
+        requestingUserId,
+        targetUuid
+      });
+      if (!['success', 'duplicate'].includes(result?.status)) failures.push(result);
+    }
+    if (!failures.length) return;
+
+    this.#deps.notify(
+      failures.some((result) => result?.status === 'unsafe') ? 'error' : 'warn',
+      this.#deps.localize('SWORDS_WIZARDRY.Spell.Notifications.AutoApplicationFailed', {
+        count: failures.length
+      })
+    );
+  }
+
+  #onRender(message, html) {
+    const spell = message.getFlag?.(SYSTEM_ID, SPELL_FLAG_KEY)
+      ?? message.flags?.[SYSTEM_ID]?.[SPELL_FLAG_KEY];
+    if (!spell) return;
+    const root = html.matches?.('[data-spell-message-kind]')
+      ? html
+      : html.querySelector?.('[data-spell-message-kind]') ?? html;
+    if (!root?.dataset) return;
+
+    this.#decorate(message, root, spell);
+    if (root.dataset.spellControllerBound === 'true') return;
+    root.dataset.spellControllerBound = 'true';
+    root.addEventListener('click', async (event) => {
+      const button = event.target?.closest?.('button[data-action]');
+      if (!button || (root.contains && !root.contains(button))) return;
+      if (button.dataset.action === 'spellAction') {
+        await this.#runButton(button, () => this.#deps.spellService.invoke(
+          message,
+          button.dataset.spellActionId
+        ));
+      }
+      if (button.dataset.action === 'spellApply') {
+        await this.#runButton(button, () => this.#deps.applicationService.apply(message, {
+          targetUuid: button.dataset.targetUuid,
+          kind: button.dataset.kind,
+          multiplier: Number(button.dataset.multiplier)
+        }));
+      }
+    });
+  }
+
+  async #runButton(button, operation) {
+    button.disabled = true;
+    try {
+      const result = await operation();
+      if (result?.status === 'success' || result?.status === 'duplicate') return;
+      const key = `SWORDS_WIZARDRY.Spell.Validation.${result?.code ?? 'UNKNOWN'}`;
+      const localized = this.#deps.localize(key);
+      this.#deps.notify(
+        result?.status === 'unsafe' ? 'error' : 'warn',
+        localized === key
+          ? this.#deps.localize('SWORDS_WIZARDRY.Spell.Validation.UNKNOWN')
+          : localized
+      );
+    } finally {
+      button.disabled = false;
+    }
+  }
+
+  #decorate(message, root, spell) {
+    const isGM = this.#deps.getCurrentUser()?.isGM === true;
+    const automaticApplication = (
+      spell.messageKind === 'spell-result'
+      && ['damage', 'healing'].includes(spell.action?.kind)
+      && !this.#deps.dmAppliesDamage()
+    );
+    if (!isGM || automaticApplication) {
+      for (const controls of root.querySelectorAll?.('.spell-result__application-controls') ?? []) {
+        controls.remove();
+      }
+    }
+
+    for (const [applicationId, entry] of Object.entries(spell.application?.entries ?? {})) {
+      if (!isApplicationEntryForMessage(applicationId, entry, message.uuid)) continue;
+      const target = Array.from(
+        root.querySelectorAll?.('[data-spell-target-uuid]') ?? []
+      ).find((element) => element.dataset.spellTargetUuid === entry.targetUuid);
+      if (!target) continue;
+      for (const controls of target.querySelectorAll('.spell-result__application-controls')) {
+        controls.remove();
+      }
+      const status = target.querySelector('.spell-result__application-status');
+      if (status) {
+        status.textContent = this.#deps.localize('SWORDS_WIZARDRY.Spell.Card.Applied', {
+          amount: entry.appliedAmount
+        });
+      }
+    }
+
+    if (spell.consumption?.status === 'failed' && !root.querySelector?.('.spell-card__warning')) {
+      const warning = document.createElement('p');
+      warning.className = 'spell-card__warning';
+      warning.setAttribute('role', 'alert');
+      warning.textContent = this.#deps.localize('SWORDS_WIZARDRY.Spell.Card.ConsumptionFailed');
+      root.append(warning);
+    }
+  }
+}
+
+export function createFoundrySpellChatController(spellService, applicationService) {
+  return new SpellChatController({
+    hooks: Hooks,
+    spellService,
+    applicationService,
+    getCurrentUser: () => game.user,
+    getActiveGM: () => game.users.activeGM,
+    dmAppliesDamage: () => game.settings.get(SYSTEM_ID, 'dmAppliesDamage'),
+    localize: (key, data = {}) => game.i18n.format(key, data),
+    notify: (level, message) => ui.notifications?.[level]?.(message)
+  });
+}

--- a/module/spells/constants.mjs
+++ b/module/spells/constants.mjs
@@ -1,0 +1,66 @@
+export const SYSTEM_ID = 'swords-wizardry';
+
+export const SPELL_FLAG_KEY = 'spell';
+export const SPELL_ITEM_SCHEMA_VERSION = 1;
+export const SPELL_MESSAGE_SCHEMA_VERSION = 1;
+export const SPELL_APPLICATION_SCHEMA_VERSION = 1;
+
+export const SPELL_ACTION_KINDS = Object.freeze([
+  'damage',
+  'healing',
+  'attack',
+  'roll',
+  'effect',
+  'manual'
+]);
+
+export const SPELL_TARGET_MODES = Object.freeze([
+  'none',
+  'single',
+  'selected',
+  'manual'
+]);
+
+export const SPELL_SAVE_OUTCOMES = Object.freeze([
+  'none',
+  'negates',
+  'half',
+  'partial',
+  'custom'
+]);
+
+export const SPELL_ATTACK_MODES = Object.freeze([
+  'none',
+  'melee',
+  'missile',
+  'custom'
+]);
+
+export const SPELL_LEVEL_SOURCES = Object.freeze([
+  'automatic',
+  'fixed',
+  'prompt',
+  'characterLevel',
+  'npcHitDice'
+]);
+
+export const SPELL_ACTION_LIMITS = Object.freeze({
+  count: 32,
+  id: 64,
+  label: 100,
+  formula: 200,
+  notes: 1000,
+  effectReference: 500,
+  targetCount: 100,
+  hitPointAmount: 1_000_000
+});
+
+export const SPELL_FORMULA_PATHS = Object.freeze([
+  'spell.level',
+  'spell.casterLevel',
+  'spell.abilityModifier'
+]);
+
+export const SPELL_APPLICATION_MULTIPLIERS = Object.freeze([0.5, 1, 2]);
+
+export const SPELL_APPLICATION_OPERATION = 'applyHitPoints';

--- a/module/spells/domain.mjs
+++ b/module/spells/domain.mjs
@@ -1,0 +1,572 @@
+import {
+  SPELL_ACTION_KINDS,
+  SPELL_ACTION_LIMITS,
+  SPELL_APPLICATION_MULTIPLIERS,
+  SPELL_APPLICATION_OPERATION,
+  SPELL_APPLICATION_SCHEMA_VERSION,
+  SPELL_ATTACK_MODES,
+  SPELL_FORMULA_PATHS,
+  SPELL_LEVEL_SOURCES,
+  SPELL_MESSAGE_SCHEMA_VERSION,
+  SPELL_SAVE_OUTCOMES,
+  SPELL_TARGET_MODES
+} from './constants.mjs';
+
+const ACTION_FIELDS = new Set([
+  'id', 'kind', 'label', 'formula', 'target', 'save', 'attack', 'effect', 'notes'
+]);
+const TARGET_FIELDS = new Set(['mode']);
+const SAVE_FIELDS = new Set(['outcome', 'notes']);
+const ATTACK_FIELDS = new Set(['mode', 'notes']);
+const EFFECT_FIELDS = new Set(['reference']);
+const APPLICATION_FIELDS = new Set([
+  'schemaVersion',
+  'requestId',
+  'operation',
+  'messageUuid',
+  'actionId',
+  'actionFingerprint',
+  'targetUuid',
+  'kind',
+  'amount',
+  'multiplier'
+]);
+const FORMULA_ACTION_KINDS = new Set(['damage', 'healing', 'attack', 'roll']);
+const UUID_PATTERN = /^[A-Za-z][A-Za-z0-9_-]*(?:\.[A-Za-z0-9_-]+)+$/;
+const ACTION_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+const REQUEST_ID_PATTERN = /^[A-Za-z0-9_-]{8,64}$/;
+const FORMULA_REFERENCE_PATTERN = /@([A-Za-z][A-Za-z0-9_.]*)/g;
+
+export class SpellValidationError extends Error {
+  constructor(code, details = {}) {
+    super(code);
+    this.name = 'SpellValidationError';
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export function normalizeSpellAction(action = {}, { generateId } = {}) {
+  assertPlainObject(action, 'INVALID_ACTION');
+  assertKnownFields(action, ACTION_FIELDS);
+
+  const kind = normalizeChoice(
+    action.kind ?? 'manual',
+    SPELL_ACTION_KINDS,
+    'INVALID_ACTION_KIND'
+  );
+  const id = normalizeActionId(action.id ?? generateId?.());
+  const label = normalizeText(action.label, {
+    field: 'label',
+    max: SPELL_ACTION_LIMITS.label,
+    required: true
+  });
+  const formula = normalizeText(action.formula, {
+    field: 'formula',
+    max: SPELL_ACTION_LIMITS.formula
+  });
+
+  if (FORMULA_ACTION_KINDS.has(kind) && !formula) {
+    throw new SpellValidationError('FORMULA_REQUIRED', { kind });
+  }
+  if (formula) validateFormulaReferences(formula);
+
+  const target = normalizeNested(action.target, TARGET_FIELDS, {
+    mode: normalizeChoice(
+      action.target?.mode ?? 'none',
+      SPELL_TARGET_MODES,
+      'INVALID_TARGET_MODE'
+    )
+  });
+  const save = normalizeNested(action.save, SAVE_FIELDS, {
+    outcome: normalizeChoice(
+      action.save?.outcome ?? 'none',
+      SPELL_SAVE_OUTCOMES,
+      'INVALID_SAVE_OUTCOME'
+    ),
+    notes: normalizeText(action.save?.notes, {
+      field: 'save.notes',
+      max: SPELL_ACTION_LIMITS.notes
+    })
+  });
+  if (save.outcome !== 'none' && !save.notes) {
+    throw new SpellValidationError('SAVE_NOTES_REQUIRED', { outcome: save.outcome });
+  }
+
+  const attack = normalizeNested(action.attack, ATTACK_FIELDS, {
+    mode: normalizeChoice(
+      action.attack?.mode ?? 'none',
+      SPELL_ATTACK_MODES,
+      'INVALID_ATTACK_MODE'
+    ),
+    notes: normalizeText(action.attack?.notes, {
+      field: 'attack.notes',
+      max: SPELL_ACTION_LIMITS.notes
+    })
+  });
+  if (kind === 'attack' && attack.mode === 'none') {
+    throw new SpellValidationError('ATTACK_MODE_REQUIRED');
+  }
+  if (attack.mode === 'custom' && !attack.notes) {
+    throw new SpellValidationError('ATTACK_NOTES_REQUIRED');
+  }
+
+  const effect = normalizeNested(action.effect, EFFECT_FIELDS, {
+    reference: normalizeText(action.effect?.reference, {
+      field: 'effect.reference',
+      max: SPELL_ACTION_LIMITS.effectReference
+    })
+  });
+  if (kind === 'effect' && !effect.reference && !action.notes?.trim()) {
+    throw new SpellValidationError('EFFECT_REFERENCE_OR_NOTES_REQUIRED');
+  }
+
+  return {
+    id,
+    kind,
+    label,
+    formula,
+    target,
+    save,
+    attack,
+    effect,
+    notes: normalizeText(action.notes, {
+      field: 'notes',
+      max: SPELL_ACTION_LIMITS.notes
+    })
+  };
+}
+
+export function normalizeSpellActions(actions = [], { generateId } = {}) {
+  if (!Array.isArray(actions)) throw new SpellValidationError('INVALID_ACTIONS');
+  if (actions.length > SPELL_ACTION_LIMITS.count) {
+    throw new SpellValidationError('TOO_MANY_ACTIONS', {
+      count: actions.length,
+      maximum: SPELL_ACTION_LIMITS.count
+    });
+  }
+
+  const normalized = actions.map((action, index) => normalizeSpellAction(action, {
+    generateId: () => generateId?.() ?? `action-${index + 1}`
+  }));
+  const ids = new Set();
+  for (const action of normalized) {
+    if (ids.has(action.id)) {
+      throw new SpellValidationError('DUPLICATE_ACTION_ID', { id: action.id });
+    }
+    ids.add(action.id);
+  }
+  return normalized;
+}
+
+export function validateFormulaReferences(formula) {
+  const normalized = normalizeText(formula, {
+    field: 'formula',
+    max: SPELL_ACTION_LIMITS.formula,
+    required: true
+  });
+  const references = [];
+  for (const match of normalized.matchAll(FORMULA_REFERENCE_PATTERN)) {
+    const path = match[1];
+    if (!SPELL_FORMULA_PATHS.includes(path)) {
+      throw new SpellValidationError('UNSUPPORTED_FORMULA_REFERENCE', { path });
+    }
+    references.push(path);
+  }
+  return references;
+}
+
+export function normalizeCasting(casting = {}) {
+  assertPlainObject(casting, 'INVALID_CASTING');
+  assertKnownFields(casting, new Set(['levelSource', 'fixedLevel']));
+  const levelSource = normalizeChoice(
+    casting.levelSource ?? 'automatic',
+    SPELL_LEVEL_SOURCES,
+    'INVALID_LEVEL_SOURCE'
+  );
+  const rawFixedLevel = casting.fixedLevel ?? null;
+  const fixedLevel = rawFixedLevel === '' || rawFixedLevel == null
+    ? null
+    : normalizePositiveInteger(rawFixedLevel, 'INVALID_FIXED_LEVEL');
+  if (levelSource === 'fixed' && fixedLevel == null) {
+    throw new SpellValidationError('FIXED_LEVEL_REQUIRED');
+  }
+  return { levelSource, fixedLevel };
+}
+
+export function resolveCasterLevel(casting = {}, actor = null) {
+  const normalized = normalizeCasting(casting);
+  switch (normalized.levelSource) {
+    case 'fixed':
+      return { status: 'resolved', source: 'fixed', value: normalized.fixedLevel };
+    case 'prompt':
+      return { status: 'prompt', source: 'prompt', reason: 'PROMPT_REQUIRED' };
+    case 'automatic': {
+      const value = actor?.type === 'character'
+        ? parseSinglePositiveInteger(actor.system?.level?.value)
+        : actor?.type === 'npc'
+          ? parseNpcHitDice(actor.system?.hd)
+          : null;
+      return value == null
+        ? {
+            status: 'prompt',
+            source: 'automatic',
+            reason: 'AUTOMATIC_REQUIRES_PROMPT'
+          }
+        : { status: 'resolved', source: 'automatic', value };
+    }
+    case 'characterLevel': {
+      if (actor?.type !== 'character') {
+        return {
+          status: 'prompt',
+          source: 'characterLevel',
+          reason: 'CHARACTER_REQUIRED'
+        };
+      }
+      const value = parseSinglePositiveInteger(actor.system?.level?.value);
+      return value == null
+        ? {
+            status: 'prompt',
+            source: 'characterLevel',
+            reason: 'AMBIGUOUS_CHARACTER_LEVEL'
+          }
+        : { status: 'resolved', source: 'characterLevel', value };
+    }
+    case 'npcHitDice': {
+      if (actor?.type !== 'npc') {
+        return { status: 'prompt', source: 'npcHitDice', reason: 'NPC_REQUIRED' };
+      }
+      const value = parseNpcHitDice(actor.system?.hd);
+      return value == null
+        ? { status: 'prompt', source: 'npcHitDice', reason: 'AMBIGUOUS_NPC_HIT_DICE' }
+        : { status: 'resolved', source: 'npcHitDice', value };
+    }
+    default:
+      throw new SpellValidationError('INVALID_LEVEL_SOURCE');
+  }
+}
+
+export function createSpellRollData({ spellLevel, casterLevel, abilityModifier = null }) {
+  const level = normalizeNonNegativeInteger(spellLevel, 'INVALID_SPELL_LEVEL');
+  const resolvedCasterLevel = normalizePositiveInteger(casterLevel, 'INVALID_CASTER_LEVEL');
+  let resolvedAbilityModifier = null;
+  if (abilityModifier != null && abilityModifier !== '') {
+    resolvedAbilityModifier = Number(abilityModifier);
+    if (!Number.isFinite(resolvedAbilityModifier)) {
+      throw new SpellValidationError('INVALID_ABILITY_MODIFIER');
+    }
+  }
+  return {
+    spell: {
+      level,
+      casterLevel: resolvedCasterLevel,
+      abilityModifier: resolvedAbilityModifier
+    }
+  };
+}
+
+export function fingerprintAction(action) {
+  const canonical = canonicalStringify(action);
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < canonical.length; index += 1) {
+    hash ^= canonical.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+export function buildSpellMessageSnapshot({
+  item,
+  caster = null,
+  casting,
+  targetUuids = []
+}) {
+  assertPlainObject(item, 'INVALID_ITEM_SNAPSHOT');
+  assertUuid(item.uuid, 'INVALID_ITEM_UUID');
+  const actions = normalizeSpellActions(item.system?.actions ?? []);
+  const casterLevel = normalizePositiveInteger(casting?.casterLevel, 'INVALID_CASTER_LEVEL');
+  const castingSource = normalizeChoice(
+    casting?.source,
+    SPELL_LEVEL_SOURCES,
+    'INVALID_LEVEL_SOURCE'
+  );
+  if (targetUuids.length > SPELL_ACTION_LIMITS.targetCount) {
+    throw new SpellValidationError('TOO_MANY_TARGETS');
+  }
+  const stableTargetUuids = targetUuids.map((uuid) => {
+    assertUuid(uuid, 'INVALID_TARGET_UUID');
+    return uuid;
+  });
+  if (caster?.uuid) assertUuid(caster.uuid, 'INVALID_CASTER_UUID');
+
+  return deepFreeze({
+    schemaVersion: SPELL_MESSAGE_SCHEMA_VERSION,
+    messageKind: 'spell-card',
+    sourceItemUuid: item.uuid,
+    sourceActorUuid: caster?.uuid ?? null,
+    casterUuid: caster?.uuid ?? null,
+    casterName: normalizeText(caster?.name, {
+      field: 'caster.name',
+      max: SPELL_ACTION_LIMITS.label
+    }),
+    casting: { casterLevel, source: castingSource },
+    item: {
+      name: normalizeText(item.name, {
+        field: 'item.name',
+        max: SPELL_ACTION_LIMITS.label,
+        required: true
+      }),
+      img: normalizeText(item.img, { field: 'item.img', max: 500 }),
+      description: String(item.system?.description ?? ''),
+      spellLevel: normalizeNonNegativeInteger(
+        item.system?.spellLevel ?? 0,
+        'INVALID_SPELL_LEVEL'
+      ),
+      range: normalizeText(item.system?.range, { field: 'item.range', max: 500 }),
+      duration: normalizeText(item.system?.duration, {
+        field: 'item.duration',
+        max: 500
+      })
+    },
+    actions: actions.map((action) => ({
+      ...action,
+      fingerprint: fingerprintAction(action)
+    })),
+    targetUuids: stableTargetUuids
+  });
+}
+
+export function planSpellAction({
+  action,
+  spellLevel,
+  casterLevel,
+  abilityModifier = null,
+  targetUuids = []
+}) {
+  const normalizedAction = normalizeSpellAction(action);
+  const references = normalizedAction.formula
+    ? validateFormulaReferences(normalizedAction.formula)
+    : [];
+  if (references.includes('spell.abilityModifier') && abilityModifier == null) {
+    throw new SpellValidationError('ABILITY_MODIFIER_REQUIRED');
+  }
+  if (targetUuids.length > SPELL_ACTION_LIMITS.targetCount) {
+    throw new SpellValidationError('TOO_MANY_TARGETS');
+  }
+  const stableTargetUuids = targetUuids.map((uuid) => {
+    assertUuid(uuid, 'INVALID_TARGET_UUID');
+    return uuid;
+  });
+  return {
+    actionId: normalizedAction.id,
+    actionFingerprint: fingerprintAction(normalizedAction),
+    kind: normalizedAction.kind,
+    label: normalizedAction.label,
+    formula: normalizedAction.formula,
+    target: structuredCopy(normalizedAction.target),
+    save: structuredCopy(normalizedAction.save),
+    attack: structuredCopy(normalizedAction.attack),
+    effect: structuredCopy(normalizedAction.effect),
+    notes: normalizedAction.notes,
+    rollData: createSpellRollData({ spellLevel, casterLevel, abilityModifier }),
+    targetUuids: stableTargetUuids
+  };
+}
+
+export function consumePreparedSpell(prepared, spellId) {
+  if (!Array.isArray(prepared)) throw new SpellValidationError('INVALID_PREPARED_LIST');
+  const next = [...prepared];
+  const index = next.indexOf(spellId);
+  if (index === -1) return { status: 'missing', index, prepared: next };
+  next.splice(index, 1);
+  return { status: 'consumed', index, prepared: next };
+}
+
+export function applyHitPointChange({
+  kind,
+  current,
+  maximum,
+  amount,
+  multiplier = 1
+}) {
+  if (!['damage', 'healing'].includes(kind)) {
+    throw new SpellValidationError('INVALID_HP_KIND', { kind });
+  }
+  const oldHP = normalizeNonNegativeInteger(current, 'INVALID_CURRENT_HP');
+  const maximumHP = normalizeNonNegativeInteger(maximum, 'INVALID_MAXIMUM_HP');
+  const numericAmount = Number(amount);
+  if (
+    !Number.isFinite(numericAmount)
+    || numericAmount < 0
+    || numericAmount > SPELL_ACTION_LIMITS.hitPointAmount
+  ) {
+    throw new SpellValidationError('INVALID_HP_AMOUNT');
+  }
+  if (!SPELL_APPLICATION_MULTIPLIERS.includes(multiplier)) {
+    throw new SpellValidationError('INVALID_HP_MULTIPLIER');
+  }
+  const requestedAmount = Math.floor(numericAmount * multiplier);
+  const newHP = kind === 'damage'
+    ? Math.max(0, oldHP - requestedAmount)
+    : Math.max(oldHP, Math.min(maximumHP, oldHP + requestedAmount));
+  return {
+    oldHP,
+    newHP,
+    requestedAmount,
+    appliedAmount: Math.abs(newHP - oldHP)
+  };
+}
+
+export function validateApplicationRequest(request = {}) {
+  assertPlainObject(request, 'INVALID_APPLICATION_REQUEST');
+  assertKnownFields(request, APPLICATION_FIELDS);
+  if (request.schemaVersion !== SPELL_APPLICATION_SCHEMA_VERSION) {
+    throw new SpellValidationError('INVALID_APPLICATION_SCHEMA');
+  }
+  if (!REQUEST_ID_PATTERN.test(String(request.requestId ?? ''))) {
+    throw new SpellValidationError('INVALID_REQUEST_ID');
+  }
+  if (request.operation !== SPELL_APPLICATION_OPERATION) {
+    throw new SpellValidationError('INVALID_APPLICATION_OPERATION');
+  }
+  assertUuid(request.messageUuid, 'INVALID_MESSAGE_UUID');
+  assertUuid(request.targetUuid, 'INVALID_TARGET_UUID');
+  const actionId = normalizeActionId(request.actionId);
+  const actionFingerprint = normalizeText(request.actionFingerprint, {
+    field: 'actionFingerprint',
+    max: 64,
+    required: true
+  });
+  if (!['damage', 'healing'].includes(request.kind)) {
+    throw new SpellValidationError('INVALID_HP_KIND');
+  }
+  const amount = Number(request.amount);
+  if (
+    !Number.isFinite(amount)
+    || amount < 0
+    || amount > SPELL_ACTION_LIMITS.hitPointAmount
+  ) {
+    throw new SpellValidationError('INVALID_HP_AMOUNT');
+  }
+  const multiplier = Number(request.multiplier);
+  if (!SPELL_APPLICATION_MULTIPLIERS.includes(multiplier)) {
+    throw new SpellValidationError('INVALID_HP_MULTIPLIER');
+  }
+  return {
+    schemaVersion: request.schemaVersion,
+    requestId: request.requestId,
+    operation: request.operation,
+    messageUuid: request.messageUuid,
+    actionId,
+    actionFingerprint,
+    targetUuid: request.targetUuid,
+    kind: request.kind,
+    amount,
+    multiplier
+  };
+}
+
+function normalizeNested(source, allowedFields, normalized) {
+  if (source != null) {
+    assertPlainObject(source, 'INVALID_NESTED_FIELD');
+    assertKnownFields(source, allowedFields);
+  }
+  return normalized;
+}
+
+function normalizeChoice(value, choices, code) {
+  if (!choices.includes(value)) throw new SpellValidationError(code, { value });
+  return value;
+}
+
+function normalizeActionId(value) {
+  const id = normalizeText(value, {
+    field: 'id',
+    max: SPELL_ACTION_LIMITS.id,
+    required: true
+  });
+  if (!ACTION_ID_PATTERN.test(id)) throw new SpellValidationError('INVALID_ACTION_ID');
+  return id;
+}
+
+function normalizeText(value, { field, max, required = false }) {
+  const normalized = String(value ?? '').trim();
+  if (required && !normalized) {
+    throw new SpellValidationError('TEXT_REQUIRED', { field });
+  }
+  if (normalized.length > max) {
+    throw new SpellValidationError('TEXT_TOO_LONG', { field, maximum: max });
+  }
+  return normalized;
+}
+
+function normalizePositiveInteger(value, code) {
+  const number = Number(value);
+  if (!Number.isSafeInteger(number) || number < 1) {
+    throw new SpellValidationError(code, { value });
+  }
+  return number;
+}
+
+function normalizeNonNegativeInteger(value, code) {
+  const number = Number(value);
+  if (!Number.isSafeInteger(number) || number < 0) {
+    throw new SpellValidationError(code, { value });
+  }
+  return number;
+}
+
+function parseSinglePositiveInteger(value) {
+  const text = String(value ?? '').trim();
+  if (!/^[1-9]\d*$/.test(text)) return null;
+  const parsed = Number(text);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function parseNpcHitDice(value) {
+  const text = String(value ?? '').trim();
+  const match = /^([1-9]\d*)(?:\s*[+-]\s*\d+)?$/.exec(text);
+  if (!match) return null;
+  const parsed = Number(match[1]);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function assertUuid(value, code) {
+  if (!UUID_PATTERN.test(String(value ?? ''))) {
+    throw new SpellValidationError(code, { value });
+  }
+}
+
+function assertPlainObject(value, code) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new SpellValidationError(code);
+  }
+}
+
+function assertKnownFields(value, allowed) {
+  const unknown = Object.keys(value).find((key) => !allowed.has(key));
+  if (unknown) throw new SpellValidationError('UNKNOWN_FIELD', { field: unknown });
+}
+
+function canonicalStringify(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonicalStringify(entry)).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value).sort().map((key) => (
+      `${JSON.stringify(key)}:${canonicalStringify(value[key])}`
+    )).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function structuredCopy(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function deepFreeze(value) {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  Object.freeze(value);
+  for (const child of Object.values(value)) deepFreeze(child);
+  return value;
+}

--- a/module/spells/editor-state.mjs
+++ b/module/spells/editor-state.mjs
@@ -1,0 +1,71 @@
+const EFFECT_TYPES = new Set(['damage', 'healing', 'attack', 'roll', 'effect', 'manual']);
+const FORMULA_EFFECT_TYPES = new Set(['damage', 'healing', 'attack', 'roll']);
+const SAVE_EFFECT_TYPES = new Set(['damage', 'effect']);
+const NOTES_EFFECT_TYPES = new Set(['effect', 'manual']);
+
+export function effectEditorVisibility(kind, { saveOutcome = 'none', attackMode = 'none' } = {}) {
+  if (!EFFECT_TYPES.has(kind)) throw new TypeError(`Unknown spell effect type: ${kind}`);
+  const save = SAVE_EFFECT_TYPES.has(kind);
+  const attack = kind === 'attack';
+  return {
+    formula: FORMULA_EFFECT_TYPES.has(kind),
+    target: true,
+    save,
+    saveNotes: save && saveOutcome !== 'none',
+    attack,
+    attackNotes: attack && attackMode === 'custom',
+    reference: kind === 'effect',
+    notes: NOTES_EFFECT_TYPES.has(kind)
+  };
+}
+
+export function actionsFromFormData(value) {
+  if (value == null) return [];
+  if (Array.isArray(value)) return value.map(copyAction);
+  if (!value || typeof value !== 'object') throw new TypeError('Invalid action form data.');
+  return Object.entries(value)
+    .filter(([key]) => /^\d+$/.test(key))
+    .sort(([left], [right]) => Number(left) - Number(right))
+    .map(([, action]) => copyAction(action));
+}
+
+export function moveAction(actions, index, direction) {
+  if (!Array.isArray(actions)) throw new TypeError('Actions must be an array.');
+  if (!Number.isInteger(index) || ![-1, 1].includes(direction)) return [...actions];
+  const destination = index + direction;
+  if (index < 0 || index >= actions.length || destination < 0 || destination >= actions.length) {
+    return [...actions];
+  }
+  const moved = actions.map(copyAction);
+  [moved[index], moved[destination]] = [moved[destination], moved[index]];
+  return moved;
+}
+
+export function actionsFromFormElements(form, count) {
+  if (!form?.elements) throw new TypeError('A form with elements is required.');
+  return Array.from({ length: count }, (_, index) => ({
+    id: read(`actions.${index}.id`),
+    kind: read(`actions.${index}.kind`),
+    label: read(`actions.${index}.label`),
+    formula: read(`actions.${index}.formula`),
+    target: { mode: read(`actions.${index}.target.mode`) },
+    save: {
+      outcome: read(`actions.${index}.save.outcome`),
+      notes: read(`actions.${index}.save.notes`)
+    },
+    attack: {
+      mode: read(`actions.${index}.attack.mode`),
+      notes: read(`actions.${index}.attack.notes`)
+    },
+    effect: { reference: read(`actions.${index}.effect.reference`) },
+    notes: read(`actions.${index}.notes`)
+  }));
+
+  function read(name) {
+    return form.elements.namedItem(name)?.value ?? '';
+  }
+}
+
+function copyAction(action) {
+  return JSON.parse(JSON.stringify(action));
+}

--- a/module/spells/service.mjs
+++ b/module/spells/service.mjs
@@ -1,0 +1,470 @@
+import {
+  SpellValidationError,
+  buildSpellMessageSnapshot,
+  consumePreparedSpell,
+  fingerprintAction,
+  normalizeSpellAction,
+  planSpellAction,
+  resolveCasterLevel
+} from './domain.mjs';
+import {
+  SPELL_FLAG_KEY,
+  SPELL_MESSAGE_SCHEMA_VERSION,
+  SYSTEM_ID
+} from './constants.mjs';
+import { evaluateAttackPlan } from './attack-plan.mjs';
+
+const SPELL_CARD_TEMPLATE = `systems/${SYSTEM_ID}/module/templates/spells/spell-card.hbs`;
+const SPELL_RESULT_TEMPLATE = `systems/${SYSTEM_ID}/module/templates/spells/action-result.hbs`;
+const VISIBILITY_MODES = Object.freeze({
+  publicroll: 'public',
+  gmroll: 'gm',
+  blindroll: 'blind',
+  selfroll: 'self',
+  roll: undefined
+});
+const LEGACY_ROLL_MODES = Object.freeze({
+  public: 'publicroll',
+  gm: 'gmroll',
+  blind: 'blindroll',
+  self: 'selfroll'
+});
+
+export class SpellService {
+  #deps;
+  #castLocks = new Set();
+  #actionLocks = new Set();
+
+  constructor(dependencies) {
+    this.#deps = validateDependencies(dependencies);
+  }
+
+  async post(itemOrUuid, options = {}) {
+    try {
+      const item = await this.#resolveSpellItem(itemOrUuid);
+      const authorization = await this.#canUseItem(item);
+      if (!authorization) return failure('NOT_AUTHORIZED');
+      return await this.#createSpellCard(item, options);
+    } catch (error) {
+      return this.#toFailure(error, 'POST_FAILED');
+    }
+  }
+
+  async cast(itemOrUuid, options = {}) {
+    let item;
+    try {
+      item = await this.#resolveSpellItem(itemOrUuid);
+    } catch (error) {
+      return this.#toFailure(error, 'ITEM_NOT_FOUND');
+    }
+    const actor = item.actor ?? item.parent ?? null;
+    if (!actor?.uuid || !actor.isOwner) return failure('NOT_AUTHORIZED');
+
+    const lockKey = `${actor.uuid}:${item.id ?? item._id}`;
+    if (this.#castLocks.has(lockKey)) return failure('CAST_IN_PROGRESS');
+    this.#castLocks.add(lockKey);
+
+    try {
+      const prepared = this.#getPrepared(actor, item);
+      if (prepared.status === 'missing') return failure('SPELL_NOT_PREPARED');
+
+      const posted = await this.#createSpellCard(item, {
+        ...options,
+        consumption: { status: 'pending' }
+      });
+      if (posted.status !== 'success') return posted;
+
+      const currentPrepared = this.#getPrepared(actor, item);
+      if (currentPrepared.status === 'missing') {
+        await this.#markConsumption(posted.message, {
+          status: 'failed',
+          reason: 'STALE_PREPARATION'
+        });
+        return failure('STALE_PREPARATION', { message: posted.message });
+      }
+
+      try {
+        await actor.update({
+          [currentPrepared.path]: currentPrepared.prepared
+        });
+      } catch (error) {
+        await this.#markConsumption(posted.message, {
+          status: 'failed',
+          reason: 'CONSUMPTION_FAILED'
+        });
+        return failure('CONSUMPTION_FAILED', { message: posted.message, error });
+      }
+
+      try {
+        await this.#markConsumption(posted.message, {
+          status: 'consumed',
+          actorUuid: actor.uuid,
+          spellId: item.id ?? item._id,
+          preparedIndex: currentPrepared.index
+        });
+      } catch (error) {
+        this.#deps.notify?.('warn', 'SWORDS_WIZARDRY.Spell.Notifications.AuditFailed');
+      }
+
+      return {
+        ...posted,
+        consumption: { status: 'consumed', index: currentPrepared.index }
+      };
+    } finally {
+      this.#castLocks.delete(lockKey);
+    }
+  }
+
+  async invoke(messageOrUuid, actionId, options = {}) {
+    let message;
+    try {
+      message = await this.#resolveDocument(messageOrUuid);
+      if (!message) return failure('MESSAGE_NOT_FOUND');
+      const snapshot = message.getFlag?.(SYSTEM_ID, SPELL_FLAG_KEY)
+        ?? message.flags?.[SYSTEM_ID]?.[SPELL_FLAG_KEY];
+      if (
+        snapshot?.schemaVersion !== SPELL_MESSAGE_SCHEMA_VERSION
+        || snapshot?.messageKind !== 'spell-card'
+      ) {
+        return failure('INVALID_MESSAGE_SCHEMA');
+      }
+      if (!await this.#canInvokeMessage(message, snapshot)) {
+        return failure('NOT_AUTHORIZED');
+      }
+
+      const storedAction = snapshot.actions?.find((entry) => entry.id === actionId);
+      if (!storedAction) return failure('ACTION_NOT_FOUND');
+      const { fingerprint: storedFingerprint, ...actionSource } = storedAction;
+      const action = normalizeSpellAction(actionSource);
+      if (storedFingerprint !== fingerprintAction(action)) return failure('STALE_ACTION');
+
+      const lockKey = `${message.uuid}:${action.id}`;
+      if (this.#actionLocks.has(lockKey)) return failure('ACTION_IN_PROGRESS');
+      this.#actionLocks.add(lockKey);
+      try {
+        const targetUuids = this.#resolveInvocationTargets(action, options);
+        const plan = planSpellAction({
+          action,
+          spellLevel: snapshot.item.spellLevel,
+          casterLevel: snapshot.casting.casterLevel,
+          abilityModifier: options.abilityModifier ?? null,
+          targetUuids
+        });
+        const targetSummaries = await this.#resolveTargetSummaries(targetUuids);
+        const evaluation = plan.formula
+          ? await this.#deps.evaluateRoll(plan.formula, plan.rollData, {
+              rollMode: options.rollMode ?? this.#deps.getRollMode()
+            })
+          : null;
+        if (evaluation && !Number.isFinite(evaluation.total)) {
+          return failure('NON_FINITE_ROLL');
+        }
+
+        const caster = snapshot.casterUuid
+          ? await this.#deps.resolveUuid(snapshot.casterUuid)
+          : null;
+        const attackResults = plan.kind === 'attack'
+          ? evaluateAttackPlan({
+              total: evaluation?.total,
+              mode: plan.attack.mode,
+              useAscendingAC: this.#deps.useAscendingAC?.() === true,
+              attacker: caster?.system ?? {},
+              targets: targetSummaries
+            })
+          : [];
+        const resultTargets = targetSummaries.map((target) => {
+          const attackResult = attackResults.find((entry) => entry.uuid === target.uuid);
+          return attackResult
+            ? {
+                ...target,
+                attackOutcome: attackResult.outcome,
+                attackTargetNumber: attackResult.targetNumber ?? null
+              }
+            : target;
+        });
+        const resultFlags = {
+          schemaVersion: SPELL_MESSAGE_SCHEMA_VERSION,
+          messageKind: 'spell-result',
+          sourceMessageUuid: message.uuid,
+          sourceItemUuid: snapshot.sourceItemUuid,
+          sourceActorUuid: snapshot.sourceActorUuid,
+          casterUuid: snapshot.casterUuid,
+          casting: structuredCopy(snapshot.casting),
+          item: structuredCopy(snapshot.item),
+          action: { ...action, fingerprint: storedFingerprint },
+          targetUuids: [...targetUuids],
+          targets: resultTargets,
+          result: {
+            formula: evaluation?.formula ?? plan.formula,
+            total: evaluation?.total ?? null,
+            attackResults
+          },
+          application: { entries: {} }
+        };
+        const renderSpell = {
+          ...resultFlags,
+          targets: resultFlags.targets.map((target) => ({
+            ...target,
+            attackOutcomeLabel: target.attackOutcome
+              ? this.#deps.localize(
+                  `SWORDS_WIZARDRY.Spell.Card.AttackOutcome.${target.attackOutcome}`
+                )
+              : ''
+          }))
+        };
+        const content = await this.#deps.renderTemplate(SPELL_RESULT_TEMPLATE, {
+          spell: renderSpell,
+          rollHTML: evaluation?.html ?? ''
+        });
+        const created = await this.#deps.createChatMessage({
+          speaker: this.#deps.getSpeaker({ actor: caster }),
+          rollMode: options.rollMode ?? this.#deps.getRollMode(),
+          content,
+          rolls: evaluation?.roll ? [evaluation.roll] : [],
+          flags: { [SYSTEM_ID]: { [SPELL_FLAG_KEY]: resultFlags } }
+        });
+        return { status: 'success', message: created, plan, result: resultFlags };
+      } finally {
+        this.#actionLocks.delete(lockKey);
+      }
+    } catch (error) {
+      return this.#toFailure(error, 'ACTION_FAILED');
+    }
+  }
+
+  async #createSpellCard(item, options) {
+    const actor = item.actor ?? item.parent ?? null;
+    const resolved = resolveCasterLevel(item.system?.casting ?? {}, actor);
+    let casterLevel;
+    let casterLevelSource = resolved.source;
+    if (resolved.status === 'prompt') {
+      const prompted = await this.#deps.promptCasterLevel({
+        item,
+        actor,
+        reason: resolved.reason
+      });
+      if (prompted == null || prompted === '') return { status: 'cancelled' };
+      casterLevel = normalizePromptedLevel(prompted);
+      casterLevelSource = 'prompt';
+    } else {
+      casterLevel = resolved.value;
+    }
+
+    const snapshot = buildSpellMessageSnapshot({
+      item,
+      caster: actor,
+      casting: { casterLevel, source: casterLevelSource },
+      targetUuids: options.targetUuids ?? []
+    });
+    const flags = {
+      ...structuredCopy(snapshot),
+      consumption: structuredCopy(options.consumption ?? { status: 'not-applicable' })
+    };
+    const descriptionHTML = await this.#deps.enrichHTML(snapshot.item.description, {
+      relativeTo: item,
+      rollData: snapshot.casting
+    });
+    const content = await this.#deps.renderTemplate(SPELL_CARD_TEMPLATE, {
+      spell: flags,
+      descriptionHTML
+    });
+
+    try {
+      const message = await this.#deps.createChatMessage({
+        speaker: this.#deps.getSpeaker({ actor }),
+        rollMode: options.rollMode ?? this.#deps.getRollMode(),
+        content,
+        flags: { [SYSTEM_ID]: { [SPELL_FLAG_KEY]: flags } }
+      });
+      return { status: 'success', message, snapshot: flags };
+    } catch (error) {
+      return failure('MESSAGE_CREATE_FAILED', { error });
+    }
+  }
+
+  async #resolveSpellItem(itemOrUuid) {
+    const item = await this.#resolveDocument(itemOrUuid);
+    if (!item || item.type !== 'spell') throw new SpellValidationError('ITEM_NOT_FOUND');
+    return item;
+  }
+
+  async #resolveDocument(documentOrUuid) {
+    if (typeof documentOrUuid === 'string') {
+      return this.#deps.resolveUuid(documentOrUuid);
+    }
+    return documentOrUuid ?? null;
+  }
+
+  async #canUseItem(item) {
+    if (this.#deps.getCurrentUser()?.isGM) return true;
+    return item.isOwner === true;
+  }
+
+  async #canInvokeMessage(message, snapshot) {
+    const user = this.#deps.getCurrentUser();
+    if (!user) return false;
+    if (user.isGM || message.author?.id === user.id || message.user?.id === user.id) return true;
+    if (!snapshot.casterUuid) return false;
+    const caster = await this.#deps.resolveUuid(snapshot.casterUuid);
+    return caster?.isOwner === true;
+  }
+
+  #getPrepared(actor, item) {
+    const level = item.system?.spellLevel;
+    const path = `system.spellSlots.${level}.memorized`;
+    const memorized = actor.system?.spellSlots?.[level]?.memorized;
+    if (!Array.isArray(memorized)) return { status: 'missing', path, index: -1 };
+    const consumed = consumePreparedSpell(memorized, item.id ?? item._id);
+    return { ...consumed, path };
+  }
+
+  async #markConsumption(message, consumption) {
+    const currentFlags = structuredCopy(
+      message.getFlag?.(SYSTEM_ID, SPELL_FLAG_KEY)
+      ?? message.flags?.[SYSTEM_ID]?.[SPELL_FLAG_KEY]
+      ?? {}
+    );
+    currentFlags.consumption = consumption;
+    await message.update({
+      [`flags.${SYSTEM_ID}.${SPELL_FLAG_KEY}`]: currentFlags
+    });
+  }
+
+  #resolveInvocationTargets(action, options) {
+    const supplied = options.targetUuids ?? this.#deps.getSelectedTargetUuids();
+    const targetUuids = [...new Set(supplied ?? [])];
+    if (action.target.mode === 'none') return [];
+    if (action.target.mode === 'single' && targetUuids.length !== 1) {
+      throw new SpellValidationError('SINGLE_TARGET_REQUIRED');
+    }
+    if (action.target.mode === 'selected' && targetUuids.length === 0) {
+      throw new SpellValidationError('TARGET_REQUIRED');
+    }
+    return targetUuids;
+  }
+
+  async #resolveTargetSummaries(targetUuids) {
+    const summaries = [];
+    for (const uuid of targetUuids) {
+      const document = await this.#deps.resolveUuid(uuid);
+      const actor = document?.actor ?? (document?.documentName === 'Actor' ? document : null);
+      summaries.push({
+        uuid,
+        actorUuid: actor?.uuid ?? null,
+        name: document?.name ?? actor?.name ?? uuid,
+        status: actor ? 'resolved' : 'missing',
+        ac: actor?.system?.ac?.value ?? null,
+        aac: actor?.system?.aac?.value ?? null
+      });
+    }
+    return summaries;
+  }
+
+  #toFailure(error, fallbackCode) {
+    if (error instanceof SpellValidationError) {
+      return failure(error.code, { error, details: error.details });
+    }
+    return failure(fallbackCode, { error });
+  }
+}
+
+export function createFoundrySpellService() {
+  const TextEditor = foundry.applications.ux.TextEditor;
+  const DialogV2 = foundry.applications.api.DialogV2;
+  const renderTemplate = foundry.applications.handlebars.renderTemplate;
+  const resolveUuid = foundry.utils.fromUuid ?? globalThis.fromUuid;
+
+  return new SpellService({
+    resolveUuid: (uuid) => resolveUuid(uuid),
+    enrichHTML: (html, options) => TextEditor.enrichHTML(html, options),
+    renderTemplate,
+    createChatMessage: (data) => ChatMessage.create(
+      applyFoundryChatVisibility(ChatMessage, data)
+    ),
+    async evaluateRoll(formula, data) {
+      if (!Roll.validate(formula)) throw new SpellValidationError('INVALID_ROLL_FORMULA');
+      const roll = await new Roll(formula, data).evaluate();
+      return {
+        formula,
+        data,
+        total: roll.total,
+        roll,
+        html: await roll.render()
+      };
+    },
+    async promptCasterLevel({ item }) {
+      const values = await DialogV2.input({
+        window: { title: game.i18n.localize('SWORDS_WIZARDRY.Spell.CasterLevelPrompt.Title') },
+        content: `<label>${game.i18n.localize('SWORDS_WIZARDRY.Spell.CasterLevelPrompt.Label')}<input name="casterLevel" type="number" min="1" max="100" step="1" value="${Math.max(1, Number(item.system?.spellLevel) || 1)}" autofocus></label>`,
+        ok: { label: game.i18n.localize('SWORDS_WIZARDRY.Spell.Actions.Continue') },
+        rejectClose: false,
+        modal: true
+      });
+      return values?.casterLevel ?? null;
+    },
+    getSelectedTargetUuids() {
+      return Array.from(game.user?.targets ?? []).map((target) => (
+        target.document?.uuid ?? target.uuid
+      )).filter(Boolean);
+    },
+    getRollMode: () => game.settings.get('core', 'rollMode'),
+    getSpeaker: ({ actor }) => ChatMessage.getSpeaker({ actor }),
+    getCurrentUser: () => game.user,
+    localize: (key, data) => game.i18n.format(key, data),
+    notify: (level, key) => ui.notifications?.[level]?.(game.i18n.localize(key)),
+    useAscendingAC: () => game.settings.get(SYSTEM_ID, 'useAscendingAC')
+  });
+}
+
+export function applyFoundryChatVisibility(ChatMessageClass, data) {
+  const { rollMode, ...chatData } = data;
+  if (typeof ChatMessageClass?.applyMode === 'function') {
+    const visibilityMode = Object.hasOwn(VISIBILITY_MODES, rollMode)
+      ? VISIBILITY_MODES[rollMode]
+      : rollMode;
+    return ChatMessageClass.applyMode(chatData, visibilityMode) ?? chatData;
+  }
+  if (typeof ChatMessageClass?.applyRollMode === 'function') {
+    const legacyRollMode = LEGACY_ROLL_MODES[rollMode] ?? rollMode;
+    return ChatMessageClass.applyRollMode(chatData, legacyRollMode) ?? chatData;
+  }
+  throw new TypeError('ChatMessage visibility API is unavailable.');
+}
+
+function validateDependencies(dependencies) {
+  const required = [
+    'resolveUuid',
+    'enrichHTML',
+    'renderTemplate',
+    'createChatMessage',
+    'evaluateRoll',
+    'promptCasterLevel',
+    'getSelectedTargetUuids',
+    'getRollMode',
+    'getSpeaker',
+    'getCurrentUser',
+    'localize'
+  ];
+  for (const key of required) {
+    if (typeof dependencies?.[key] !== 'function') {
+      throw new TypeError(`SpellService dependency ${key} must be a function.`);
+    }
+  }
+  return dependencies;
+}
+
+function normalizePromptedLevel(value) {
+  const level = Number(value);
+  if (!Number.isSafeInteger(level) || level < 1 || level > 100) {
+    throw new SpellValidationError('INVALID_CASTER_LEVEL');
+  }
+  return level;
+}
+
+function failure(code, extra = {}) {
+  return { status: 'failure', code, ...extra };
+}
+
+function structuredCopy(value) {
+  return JSON.parse(JSON.stringify(value));
+}

--- a/module/swords-wizardry.mjs
+++ b/module/swords-wizardry.mjs
@@ -25,17 +25,34 @@ import { CombatHud } from './hud/hud.mjs';
 import { preloadHandlebarsTemplates } from './helpers/templates.mjs';
 import { handleRPC } from './helpers/rpc.mjs';
 import { SWORDS_WIZARDRY } from './helpers/config.mjs';
+import { createFoundrySpellService } from './spells/service.mjs';
+import { createFoundrySpellApplicationService } from './spells/application.mjs';
+import { createFoundrySpellChatController } from './spells/chat-controller.mjs';
 
 const { Actors, Items } = foundry.documents.collections;
 const { ActorSheet, ItemSheet } = foundry.appv1.sheets;
+let spellChatController;
 
 Hooks.once('init', function() {
   registerSystemSettings();
+
+  const spellService = createFoundrySpellService();
+  const spellApplicationService = createFoundrySpellApplicationService();
+  spellChatController = createFoundrySpellChatController(
+    spellService,
+    spellApplicationService
+  );
 
   game.swordswizardry = {
     SwordsWizardryActor,
     SwordsWizardryItem,
     rollItemMacro,
+    spells: Object.freeze({
+      post: spellService.post.bind(spellService),
+      cast: spellService.cast.bind(spellService),
+      invoke: spellService.invoke.bind(spellService),
+      requestApplication: spellApplicationService.apply.bind(spellApplicationService)
+    })
   };
 
   CONFIG.SWORDS_WIZARDRY = SWORDS_WIZARDRY;
@@ -127,6 +144,7 @@ function showWelcome() {
 }
 
 Hooks.once('ready', async () => {
+  spellChatController.start();
   if (game.user.isGM) {
     if (game.settings.get('swords-wizardry', 'systemVersion') !== game.system.version) {
       game.settings.set('swords-wizardry', 'systemVersion', game.system.version);

--- a/module/templates/spells/action-editor.hbs
+++ b/module/templates/spells/action-editor.hbs
@@ -1,0 +1,108 @@
+<div class="spell-action-editor__body">
+  <p class="hint">{{localize "SWORDS_WIZARDRY.Spell.Editor.Help"}}</p>
+
+  {{#if validationError}}
+    <div class="spell-action-editor__error" role="alert">{{validationError}}</div>
+  {{/if}}
+
+  <div class="spell-action-editor__toolbar">
+    <span>{{localize "SWORDS_WIZARDRY.Spell.Editor.ActionCount" count=actions.length maximum=limits.count}}</span>
+    <button type="button" data-action="addAction" {{#unless canAdd}}disabled{{/unless}}>
+      <i class="fas fa-plus" aria-hidden="true"></i>
+      {{localize "SWORDS_WIZARDRY.Spell.Editor.AddAction"}}
+    </button>
+  </div>
+
+  <ol class="spell-action-editor__list">
+    {{#each actions as |action index|}}
+      <li class="spell-action-editor__action" data-action-index="{{index}}">
+        <input type="hidden" name="actions.{{index}}.id" value="{{action.id}}">
+        <header>
+          <h3>{{localize "SWORDS_WIZARDRY.Spell.Editor.ActionHeading" number=action.number}}</h3>
+          <div class="spell-action-editor__order-controls">
+            <button type="button" data-action="moveActionUp" data-index="{{index}}" title="{{localize 'SWORDS_WIZARDRY.Spell.Editor.MoveUp'}}" {{#if @first}}disabled{{/if}}>
+              <i class="fas fa-arrow-up" aria-hidden="true"></i>
+              <span class="sr-only">{{localize "SWORDS_WIZARDRY.Spell.Editor.MoveUp"}}</span>
+            </button>
+            <button type="button" data-action="moveActionDown" data-index="{{index}}" title="{{localize 'SWORDS_WIZARDRY.Spell.Editor.MoveDown'}}" {{#if @last}}disabled{{/if}}>
+              <i class="fas fa-arrow-down" aria-hidden="true"></i>
+              <span class="sr-only">{{localize "SWORDS_WIZARDRY.Spell.Editor.MoveDown"}}</span>
+            </button>
+            <button type="button" data-action="removeAction" data-index="{{index}}" title="{{localize 'SWORDS_WIZARDRY.Spell.Editor.RemoveAction'}}">
+              <i class="fas fa-trash" aria-hidden="true"></i>
+              <span class="sr-only">{{localize "SWORDS_WIZARDRY.Spell.Editor.RemoveAction"}}</span>
+            </button>
+          </div>
+        </header>
+
+        <div class="spell-action-editor__grid">
+          <label>
+            <span>{{localize "SWORDS_WIZARDRY.Spell.Editor.Label"}}</span>
+            <input name="actions.{{index}}.label" type="text" value="{{action.label}}" maxlength="{{../limits.label}}" required>
+          </label>
+          <label>
+            <span>{{localize "SWORDS_WIZARDRY.Spell.Editor.Kind"}}</span>
+            <select name="actions.{{index}}.kind" data-effect-kind>
+              {{#each ../actionKinds as |option|}}
+                <option value="{{option.value}}" {{#if (eq option.value action.kind)}}selected{{/if}}>{{localize option.label}}</option>
+              {{/each}}
+            </select>
+          </label>
+          <label class="grid-span-2" data-effect-field="formula" {{#unless action.visibility.formula}}hidden{{/unless}}>
+            <span>{{localize "SWORDS_WIZARDRY.Spell.Editor.Formula"}}</span>
+            <input name="actions.{{index}}.formula" type="text" value="{{action.formula}}" maxlength="{{../limits.formula}}" placeholder="1d6 + @spell.casterLevel" data-effect-input="formula">
+          </label>
+          <label data-effect-field="target" {{#unless action.visibility.target}}hidden{{/unless}}>
+            <span>{{localize "SWORDS_WIZARDRY.Spell.Editor.TargetMode"}}</span>
+            <select name="actions.{{index}}.target.mode">
+              {{#each ../targetModes as |option|}}
+                <option value="{{option.value}}" {{#if (eq option.value action.target.mode)}}selected{{/if}}>{{localize option.label}}</option>
+              {{/each}}
+            </select>
+          </label>
+          <label data-effect-field="save" {{#unless action.visibility.save}}hidden{{/unless}}>
+            <span>{{localize "SWORDS_WIZARDRY.Spell.Editor.SaveOutcome"}}</span>
+            <select name="actions.{{index}}.save.outcome" data-effect-save>
+              {{#each ../saveOutcomes as |option|}}
+                <option value="{{option.value}}" {{#if (eq option.value action.save.outcome)}}selected{{/if}}>{{localize option.label}}</option>
+              {{/each}}
+            </select>
+          </label>
+          <label class="grid-span-2" data-effect-field="save-notes" {{#unless action.visibility.saveNotes}}hidden{{/unless}}>
+            <span>{{localize "SWORDS_WIZARDRY.Spell.Editor.SaveNotes"}}</span>
+            <textarea name="actions.{{index}}.save.notes" maxlength="{{../limits.notes}}" data-effect-input="save-notes">{{action.save.notes}}</textarea>
+          </label>
+          <label data-effect-field="attack" {{#unless action.visibility.attack}}hidden{{/unless}}>
+            <span>{{localize "SWORDS_WIZARDRY.Spell.Editor.AttackMode"}}</span>
+            <select name="actions.{{index}}.attack.mode" data-effect-attack>
+              {{#each ../attackModes as |option|}}
+                <option value="{{option.value}}" {{#if (eq option.value action.attack.mode)}}selected{{/if}}>{{localize option.label}}</option>
+              {{/each}}
+            </select>
+          </label>
+          <label data-effect-field="reference" {{#unless action.visibility.reference}}hidden{{/unless}}>
+            <span>{{localize "SWORDS_WIZARDRY.Spell.Editor.EffectReference"}}</span>
+            <input name="actions.{{index}}.effect.reference" type="text" value="{{action.effect.reference}}" maxlength="{{../limits.effectReference}}" data-effect-input="reference">
+          </label>
+          <label class="grid-span-2" data-effect-field="attack-notes" {{#unless action.visibility.attackNotes}}hidden{{/unless}}>
+            <span>{{localize "SWORDS_WIZARDRY.Spell.Editor.AttackNotes"}}</span>
+            <textarea name="actions.{{index}}.attack.notes" maxlength="{{../limits.notes}}" data-effect-input="attack-notes">{{action.attack.notes}}</textarea>
+          </label>
+          <label class="grid-span-2" data-effect-field="notes" {{#unless action.visibility.notes}}hidden{{/unless}}>
+            <span>{{localize "SWORDS_WIZARDRY.Spell.Editor.Notes"}}</span>
+            <textarea name="actions.{{index}}.notes" maxlength="{{../limits.notes}}" data-effect-input="notes">{{action.notes}}</textarea>
+          </label>
+        </div>
+      </li>
+    {{else}}
+      <li class="spell-action-editor__empty">{{localize "SWORDS_WIZARDRY.Spell.Editor.Empty"}}</li>
+    {{/each}}
+  </ol>
+
+  <footer class="spell-action-editor__footer">
+    <button type="submit">
+      <i class="fas fa-save" aria-hidden="true"></i>
+      {{localize "SWORDS_WIZARDRY.Spell.Editor.Save"}}
+    </button>
+  </footer>
+</div>

--- a/module/templates/spells/action-result.hbs
+++ b/module/templates/spells/action-result.hbs
@@ -1,0 +1,59 @@
+<article class="swords-wizardry spell-card spell-result" data-spell-message-kind="spell-result">
+  <header class="spell-card__header">
+    {{#if spell.item.img}}<img src="{{spell.item.img}}" alt="" width="36" height="36">{{/if}}
+    <div>
+      <h3>{{spell.action.label}}</h3>
+      <p>{{spell.item.name}}</p>
+    </div>
+  </header>
+
+  {{#if spell.result.formula}}
+    <div class="spell-result__roll" aria-label="{{localize 'SWORDS_WIZARDRY.Spell.Card.RollResult'}}">
+      {{{rollHTML}}}
+    </div>
+  {{/if}}
+
+  {{#if spell.action.save.notes}}
+    <p><strong>{{localize "SWORDS_WIZARDRY.Spell.Card.Save"}}:</strong> {{spell.action.save.notes}}</p>
+  {{/if}}
+  {{#if spell.action.attack.notes}}
+    <p><strong>{{localize "SWORDS_WIZARDRY.Spell.Card.Attack"}}:</strong> {{spell.action.attack.notes}}</p>
+  {{/if}}
+  {{#if spell.action.effect.reference}}
+    <p><strong>{{localize "SWORDS_WIZARDRY.Spell.Card.Effect"}}:</strong> {{spell.action.effect.reference}}</p>
+  {{/if}}
+  {{#if spell.action.notes}}<p>{{spell.action.notes}}</p>{{/if}}
+
+  {{#if spell.targets.length}}
+    <section class="spell-result__targets{{#if (eq spell.action.kind "damage")}} damage-targets{{/if}}" aria-label="{{localize 'SWORDS_WIZARDRY.Spell.Card.Targets'}}">
+      <h4>{{localize "SWORDS_WIZARDRY.Spell.Card.Targets"}}</h4>
+      <ol>
+        {{#each spell.targets as |target|}}
+          <li class="spell-result__target{{#if (eq ../spell.action.kind "damage")}} damage-target{{/if}}" data-spell-target-uuid="{{target.uuid}}">
+            <span class="spell-result__target-name{{#if (eq ../spell.action.kind "damage")}} target-name{{/if}}">{{target.name}}</span>
+            {{#if target.attackOutcome}}
+              <span class="spell-result__target-status">{{target.attackOutcomeLabel}}</span>
+            {{/if}}
+            {{#if (eq target.status "missing")}}
+              <span class="spell-result__target-status">{{localize "SWORDS_WIZARDRY.Spell.Card.MissingTarget"}}</span>
+            {{/if}}
+            <span class="spell-result__application-status" aria-live="polite"></span>
+            {{#if (eq target.status "resolved")}}
+              {{#if (or (eq ../spell.action.kind "damage") (eq ../spell.action.kind "healing"))}}
+                <div class="spell-result__application-controls{{#if (eq ../spell.action.kind "damage")}} damage-buttons{{/if}}">
+                  {{#if (eq ../spell.action.kind "damage")}}
+                    <button class="apply-damage" type="button" data-action="spellApply" data-target-uuid="{{target.uuid}}" data-kind="damage" data-multiplier="1" aria-label="{{localize 'SWORDS_WIZARDRY.Spell.Actions.ApplyDamage'}}">{{localize "SWORDS_WIZARDRY.Spell.Actions.Damage"}}</button>
+                    <button class="apply-damage" type="button" data-action="spellApply" data-target-uuid="{{target.uuid}}" data-kind="damage" data-multiplier="0.5" aria-label="{{localize 'SWORDS_WIZARDRY.Spell.Actions.ApplyHalfDamage'}}">{{localize "SWORDS_WIZARDRY.Spell.Actions.Half"}}</button>
+                    <button class="apply-damage" type="button" data-action="spellApply" data-target-uuid="{{target.uuid}}" data-kind="damage" data-multiplier="2" aria-label="{{localize 'SWORDS_WIZARDRY.Spell.Actions.ApplyDoubleDamage'}}">{{localize "SWORDS_WIZARDRY.Spell.Actions.Double"}}</button>
+                  {{else}}
+                    <button type="button" data-action="spellApply" data-target-uuid="{{target.uuid}}" data-kind="healing" data-multiplier="1">{{localize "SWORDS_WIZARDRY.Spell.Actions.ApplyHealing"}}</button>
+                  {{/if}}
+                </div>
+              {{/if}}
+            {{/if}}
+          </li>
+        {{/each}}
+      </ol>
+    </section>
+  {{/if}}
+</article>

--- a/module/templates/spells/spell-card.hbs
+++ b/module/templates/spells/spell-card.hbs
@@ -1,0 +1,39 @@
+<article class="swords-wizardry spell-card" data-spell-message-kind="spell-card">
+  <header class="spell-card__header">
+    {{#if spell.item.img}}<img src="{{spell.item.img}}" alt="" width="36" height="36">{{/if}}
+    <div>
+      <h3>{{spell.item.name}}</h3>
+      {{#if spell.casterName}}<p>{{localize "SWORDS_WIZARDRY.Spell.Card.CastBy" caster=spell.casterName}}</p>{{/if}}
+    </div>
+  </header>
+
+  <dl class="spell-card__metadata">
+    <div><dt>{{localize "SWORDS_WIZARDRY.Item.Spell.Level"}}</dt><dd>{{spell.item.spellLevel}}</dd></div>
+    <div><dt>{{localize "SWORDS_WIZARDRY.Item.Spell.Range"}}</dt><dd>{{spell.item.range}}</dd></div>
+    <div><dt>{{localize "SWORDS_WIZARDRY.Item.Spell.Duration"}}</dt><dd>{{spell.item.duration}}</dd></div>
+    <div><dt>{{localize "SWORDS_WIZARDRY.Spell.Card.CasterLevel"}}</dt><dd>{{spell.casting.casterLevel}}</dd></div>
+  </dl>
+
+  <section class="spell-card__description" aria-label="{{localize 'SWORDS_WIZARDRY.Spell.Card.Description'}}">
+    {{{descriptionHTML}}}
+  </section>
+
+  {{#if spell.actions.length}}
+    <section class="spell-card__actions" aria-label="{{localize 'SWORDS_WIZARDRY.Item.Spell.Actions'}}">
+      <h4>{{localize "SWORDS_WIZARDRY.Item.Spell.Actions"}}</h4>
+      <div class="spell-card__action-list">
+        {{#each spell.actions as |action|}}
+          <button type="button" data-action="spellAction" data-spell-action-id="{{action.id}}">
+            <span>{{action.label}}</span>
+            {{#if action.formula}}<code>{{action.formula}}</code>{{/if}}
+          </button>
+          {{#if action.notes}}<p class="hint">{{action.notes}}</p>{{/if}}
+        {{/each}}
+      </div>
+    </section>
+  {{/if}}
+
+  {{#if (eq spell.consumption.status "failed")}}
+    <p class="spell-card__warning" role="alert">{{localize "SWORDS_WIZARDRY.Spell.Card.ConsumptionFailed"}}</p>
+  {{/if}}
+</article>


### PR DESCRIPTION
## Summary

This update makes spells interactive within the game world, with predefined spell effects for dealing damage, healing, descriptive effects, etc.

- Adds a **Spell Effects** editor to spell items.
- Lets spell cards roll damage, healing, attacks, and other effects.
- Shows target(s) and familiar damage or healing buttons on result cards.  The same formatting as weapon damage cards and buttons are used for spells.
- Supports caster-level formulas such as `@spell.casterLevel`.
- Uses the **DM must apply damage / healing** setting for both damage and healing.
- Improves readability in light, dark, and alternate UI themes.
- Fixes Spell Effects not saving and Apply buttons disappearing on later casts.
- Caster level can be selected via dropdown - character level for character actors, fixed level effects, prompts, NPC HD, etc.


## Testing

Tested with GM and player clients in Foundry v13.351 and v14.367.

<img width="820" height="962" alt="image" src="https://github.com/user-attachments/assets/5fa1d1d1-d166-46e6-8c44-09b9024d360a" />

<img width="1667" height="1236" alt="image" src="https://github.com/user-attachments/assets/89e1f700-5457-4eb0-a3f5-55cb61c79aa0" />

<img width="372" height="1088" alt="image" src="https://github.com/user-attachments/assets/d69d8fa7-8f9d-43d4-9237-78140c63fb99" />
