### PR TITLE
Feature: Simplified Spell Cards

### DIFF
--- a/css/swords-wizardry.css
+++ b/css/swords-wizardry.css
@@ -544,6 +544,32 @@ input {
   flex: 1;
   font-size: 11px;
 }
+.swords-wizardry .spell-card-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.swords-wizardry .spell-card-header h3 {
+  margin: 0;
+}
+.swords-wizardry .spell-card-image {
+  flex: 0 0 40px;
+  width: 40px;
+  height: 40px;
+  border: 0;
+}
+.swords-wizardry .spell-card-details {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 4px 12px;
+  margin-top: 6px;
+}
+.swords-wizardry .spell-card-description,
+.swords-wizardry .spell-card-roll,
+.swords-wizardry .spell-card-save {
+  margin-top: 6px;
+}
 .swords-wizardry .resource {
   display: flex;
   flex-direction: column;

--- a/lang/de.json
+++ b/lang/de.json
@@ -8,7 +8,21 @@
       "Special": "Special",
       "Target": "Target",
       "Success": "Success",
-      "Failure": "Failure"
+      "Failure": "Failure",
+      "Healing": "Heilung",
+      "SavingThrow": "Rettungswurf",
+      "Targets": "Ziele",
+      "CastBy": "Gewirkt von",
+      "FullEffect": "Volle Wirkung",
+      "HalfEffect": "Halbe Wirkung",
+      "NegatesSpell": "Zauber unwirksam",
+      "SuccessfulSave": "Erfolgreicher Rettungswurf",
+      "Applied": "Angewendet",
+      "HalfDamage": "Halber Schaden",
+      "HalfHealing": "Halbe Heilung",
+      "DoubleDamage": "Doppelter Schaden",
+      "NoEffect": "Keine Wirkung",
+      "OnlyGMCanApply": "Nur die Spielleitung kann Schaden oder Heilung anwenden."
     },
     "NPCSheet": {
       "Main": {
@@ -196,6 +210,14 @@
         "Level": "Zaubergrad",
         "Range": "Range",
         "Duration": "Duration",
+        "RollFormula": "Würfelformel",
+        "EffectType": "Effekttyp",
+        "EffectNone": "Keiner",
+        "EffectDamage": "Schaden",
+        "EffectHealing": "Heilung",
+        "RequiresSave": "Rettungswurf erforderlich",
+        "SaveEffect": "Bei erfolgreichem Rettungswurf",
+        "InvalidFormula": "Die Zauberformel '{formula}' ist ungültig.",
         "Tabs": {
           "Attributes": "Eigenschaften",
           "Description": "Beschreibung"

--- a/lang/en.json
+++ b/lang/en.json
@@ -8,7 +8,21 @@
       "Special": "Special",
       "Target": "Target",
       "Success": "Success",
-      "Failure": "Failure"
+      "Failure": "Failure",
+      "Healing": "Healing",
+      "SavingThrow": "Saving Throw",
+      "Targets": "Targets",
+      "CastBy": "Cast by",
+      "FullEffect": "Full Effect",
+      "HalfEffect": "Half Effect",
+      "NegatesSpell": "Negates Spell",
+      "SuccessfulSave": "Successful Save",
+      "Applied": "Applied",
+      "HalfDamage": "Half Damage",
+      "HalfHealing": "Half Healing",
+      "DoubleDamage": "Double Damage",
+      "NoEffect": "No Effect",
+      "OnlyGMCanApply": "Only the GM can apply damage or healing."
     },
     "NPCSheet": {
       "Main": {
@@ -208,6 +222,14 @@
         "Level": "Level",
         "Range": "Range",
         "Duration": "Duration",
+        "RollFormula": "Roll Formula",
+        "EffectType": "Effect Type",
+        "EffectNone": "None",
+        "EffectDamage": "Damage",
+        "EffectHealing": "Healing",
+        "RequiresSave": "Requires Saving Throw",
+        "SaveEffect": "On Successful Save",
+        "InvalidFormula": "The spell roll formula '{formula}' is invalid.",
         "Tabs": {
           "Attributes": "Attributes",
           "Description": "Description"

--- a/lang/es.json
+++ b/lang/es.json
@@ -8,7 +8,21 @@
       "Special": "Especial",
       "Target": "Objetivo",
       "Success": "Éxito",
-      "Failure": "Fallo"
+      "Failure": "Fallo",
+      "Healing": "Curación",
+      "SavingThrow": "Tirada de salvación",
+      "Targets": "Objetivos",
+      "CastBy": "Lanzado por",
+      "FullEffect": "Efecto completo",
+      "HalfEffect": "Mitad del efecto",
+      "NegatesSpell": "Anula el hechizo",
+      "SuccessfulSave": "Salvación exitosa",
+      "Applied": "Aplicado",
+      "HalfDamage": "Mitad del daño",
+      "HalfHealing": "Mitad de la curación",
+      "DoubleDamage": "Daño doble",
+      "NoEffect": "Sin efecto",
+      "OnlyGMCanApply": "Solo el DJ puede aplicar daño o curación."
     },
     "NPCSheet": {
       "Main": {
@@ -208,6 +222,14 @@
         "Level": "Nivel",
         "Range": "Alcance",
         "Duration": "Duración",
+        "RollFormula": "Fórmula de tirada",
+        "EffectType": "Tipo de efecto",
+        "EffectNone": "Ninguno",
+        "EffectDamage": "Daño",
+        "EffectHealing": "Curación",
+        "RequiresSave": "Requiere tirada de salvación",
+        "SaveEffect": "Con una salvación exitosa",
+        "InvalidFormula": "La fórmula de tirada del hechizo '{formula}' no es válida.",
         "Tabs": {
           "Attributes": "Atributos",
           "Description": "Descripción"

--- a/module/helpers/overrides.mjs
+++ b/module/helpers/overrides.mjs
@@ -22,9 +22,8 @@ export class SwordsWizardryChatMessage extends ChatMessage {
   }
 
   activateListeners(html) {
-    const dmAppliesDamage = game.settings.get('swords-wizardry', 'dmAppliesDamage');
     this._activateRollDamageListener(html);
-    if (dmAppliesDamage) this._activateApplyDamageListener(html);
+    this._activateApplyDamageListener(html);
   }
 
   _activateRollDamageListener(html) {
@@ -53,7 +52,9 @@ export class SwordsWizardryChatMessage extends ChatMessage {
     $(html).on('click', '.apply-damage', async (e) => {
 
       if (!game.user.isGM) {
-        ui.notifications.warn("Only GM can apply damage");
+        ui.notifications.warn(game.i18n.localize(
+          'SWORDS_WIZARDRY.Chat.OnlyGMCanApply'
+        ));
         return;
       }
 
@@ -64,21 +65,25 @@ export class SwordsWizardryChatMessage extends ChatMessage {
       if (!target) return;
 
       const amount
-        = action === "half" ? Math.floor(initialAmount / 2)
-	: action === "double" ? initialAmount * 2
-	: action === "heal" ? initialAmount * -1
-	: initialAmount;
+        = action === "none" ? 0
+        : action === "half" ? Math.floor(initialAmount / 2)
+        : action === "double" ? initialAmount * 2
+        : action === "heal" ? initialAmount * -1
+        : action === "half-heal" ? Math.floor(initialAmount / 2) * -1
+        : initialAmount;
 
       const oldHP = target.actor.system.hp.value;
       const newHP = oldHP - amount;
 
-      await rpc({
-        recipient: 'GM',
-        target: target.id,
-        operation: 'damage',
-        amount: amount,
-        data: { system: { hp: { value: newHP } } }
-      });
+      if (action !== "none") {
+        await rpc({
+          recipient: 'GM',
+          target: target.id,
+          operation: 'damage',
+          amount: amount,
+          data: { system: { hp: { value: newHP } } }
+        });
+      }
 
 
       const messageId = $(button)
@@ -104,9 +109,8 @@ export class SwordsWizardryChatMessage extends ChatMessage {
 
 
 Hooks.on("renderChatMessageHTML", (message, html, data) => {
-  if (game.settings.get('swords-wizardry', 'dmAppliesDamage')) {
-
-    const appliedDamage = message.getFlag("swords-wizardry", "appliedDamage") || {};
+  const appliedDamage = message.getFlag("swords-wizardry", "appliedDamage") || {};
+  if (Object.keys(appliedDamage).length) {
 
     const targets = html.querySelectorAll(".damage-target");
 
@@ -121,12 +125,15 @@ Hooks.on("renderChatMessageHTML", (message, html, data) => {
 
       const result = appliedDamage[targetId];
 
-      const label
+      const labelKey
         = result.action === "damage" ? "Damage"
-	: result.action === "heal" ? "Healing"
-	: result.action === "half" ? "Half Damage"
-	: result.action === "double" ? "Double Damage"
-	: "Damage";
+        : result.action === "heal" ? "Healing"
+        : result.action === "half" ? "HalfDamage"
+        : result.action === "half-heal" ? "HalfHealing"
+        : result.action === "double" ? "DoubleDamage"
+        : result.action === "none" ? "NoEffect"
+        : "Damage";
+      const label = game.i18n.localize(`SWORDS_WIZARDRY.Chat.${labelKey}`);
 
       const resultDiv = targetElement.querySelector(".damage-result");
       if (!resultDiv) return;
@@ -141,7 +148,10 @@ Hooks.on("renderChatMessageHTML", (message, html, data) => {
 
       // TODO This style of state update does not survive between game sessions.
       // Investigate how to keep applied results baked into the message (someday, low-pri).
-      resultDiv.innerHTML = `Applied ${label}: ${result.amount}<br/>`;
+      const applied = game.i18n.localize('SWORDS_WIZARDRY.Chat.Applied');
+      resultDiv.textContent = result.action === "none"
+        ? `${applied}: ${label}`
+        : `${applied} ${label}: ${Math.abs(result.amount)}`;
 
       const buttons = targetElement.querySelectorAll("button");
 

--- a/module/helpers/templates.mjs
+++ b/module/helpers/templates.mjs
@@ -11,6 +11,7 @@ export const preloadHandlebarsTemplates = async function () {
     'systems/swords-wizardry/module/actor/weapons.hbs',
     'systems/swords-wizardry/module/actor/items.hbs',
     'systems/swords-wizardry/module/actor/spells.hbs',
-    'systems/swords-wizardry/module/actor/effects.hbs'
+    'systems/swords-wizardry/module/actor/effects.hbs',
+    'systems/swords-wizardry/module/rolls/spell-roll-sheet.hbs'
   ]);
 };

--- a/module/item/item-model.mjs
+++ b/module/item/item-model.mjs
@@ -71,7 +71,19 @@ export class SpellData extends BaseItemData {
         required: true, integer: true, initial: 1
       }),
       range: new StringField(),
-      duration: new StringField()
+      duration: new StringField(),
+      formula: new StringField({ initial: "" }),
+      effectType: new StringField({
+        required: true,
+        choices: ["none", "damage", "healing"],
+        initial: "none"
+      }),
+      requiresSave: new BooleanField({ initial: false }),
+      saveEffect: new StringField({
+        required: true,
+        choices: ["half", "negate"],
+        initial: "negate"
+      })
     };
   }
 }

--- a/module/item/item-sheet.hbs
+++ b/module/item/item-sheet.hbs
@@ -82,6 +82,31 @@
         <input type="text" name="system.duration" value="{{system.duration}}" data-dtype="Text"/>
       </div>
     </div>
+    <div class="grid grid-2col">
+      <div class="resource">
+        <label class="resource-label">{{localize "SWORDS_WIZARDRY.Item.Spell.RollFormula"}}</label>
+        <input type="text" name="system.formula" value="{{system.formula}}" data-dtype="String" placeholder="(@lvl)d6"/>
+      </div>
+      <div class="resource">
+        <label class="resource-label">{{localize "SWORDS_WIZARDRY.Item.Spell.EffectType"}}</label>
+        <select name="system.effectType" data-dtype="String">
+          <option value="none" {{#if (eq system.effectType 'none')}}selected{{/if}}>{{localize "SWORDS_WIZARDRY.Item.Spell.EffectNone"}}</option>
+          <option value="damage" {{#if (eq system.effectType 'damage')}}selected{{/if}}>{{localize "SWORDS_WIZARDRY.Item.Spell.EffectDamage"}}</option>
+          <option value="healing" {{#if (eq system.effectType 'healing')}}selected{{/if}}>{{localize "SWORDS_WIZARDRY.Item.Spell.EffectHealing"}}</option>
+        </select>
+      </div>
+      <div class="resource">
+        <label class="resource-label">{{localize "SWORDS_WIZARDRY.Item.Spell.RequiresSave"}}</label>
+        <input type="checkbox" name="system.requiresSave" class="checkbox-small align-self-center" {{checked system.requiresSave}}/>
+      </div>
+      <div class="resource">
+        <label class="resource-label">{{localize "SWORDS_WIZARDRY.Item.Spell.SaveEffect"}}</label>
+        <select name="system.saveEffect" data-dtype="String">
+          <option value="half" {{#if (eq system.saveEffect 'half')}}selected{{/if}}>{{localize "SWORDS_WIZARDRY.Chat.HalfEffect"}}</option>
+          <option value="negate" {{#if (eq system.saveEffect 'negate')}}selected{{/if}}>{{localize "SWORDS_WIZARDRY.Chat.NegatesSpell"}}</option>
+        </select>
+      </div>
+    </div>
     {{/if}}
     {{#if (eq item.type 'weapon')}}
     <div class="grid grid-3col">

--- a/module/item/item.mjs
+++ b/module/item/item.mjs
@@ -1,4 +1,7 @@
-import { AttackRoll, FeatureRoll } from  '../rolls/rolls.mjs';
+import { AttackRoll, DamageRoll, FeatureRoll } from  '../rolls/rolls.mjs';
+
+const { renderTemplate } = foundry.applications.handlebars;
+const SPELL_ROLL_TEMPLATE = 'systems/swords-wizardry/module/rolls/spell-roll-sheet.hbs';
 
 export class SwordsWizardryItem extends Item {
 
@@ -40,6 +43,8 @@ export class SwordsWizardryItem extends Item {
         return this.getWeaponRollData(rollData);
       case 'feature':
         return this.getFeatureRollData(rollData);
+      case 'spell':
+        return this.getSpellRollData(rollData);
       default:
         return rollData;
     }
@@ -71,6 +76,57 @@ export class SwordsWizardryItem extends Item {
     return rollData;
   }
 
+  getSpellRollData(rollData) {
+    if (this.actor) {
+      Object.assign(rollData, this.actor.getRollData());
+      rollData.actor = this.actor;
+    }
+    rollData.effectType = this.system.effectType;
+    rollData.requiresSave = this.system.requiresSave;
+    rollData.saveEffect = this.system.saveEffect;
+    return rollData;
+  }
+
+  async rollSpell() {
+    const rollData = this.getRollData();
+    const formula = this.system.formula?.trim();
+
+    if (formula) {
+      try {
+        const roll = new DamageRoll(formula, rollData);
+        await roll.render();
+        return roll;
+      } catch (error) {
+        console.error('Swords & Wizardry | Invalid spell roll formula', error);
+        ui.notifications.error(game.i18n.format(
+          'SWORDS_WIZARDRY.Item.Spell.InvalidFormula',
+          { formula }
+        ));
+        return null;
+      }
+    }
+
+    const targets = this.system.requiresSave
+      ? Array.from(game.user.targets).map(target => ({
+          id: target.id,
+          name: target.name
+        }))
+      : [];
+    const content = await renderTemplate(SPELL_ROLL_TEMPLATE, {
+      item: this,
+      actor: this.actor,
+      requiresSave: this.system.requiresSave,
+      saveEffectHalf: this.system.saveEffect === 'half',
+      targets
+    });
+
+    return ChatMessage.create({
+      speaker: ChatMessage.getSpeaker({ actor: this.actor }),
+      rollMode: game.settings.get('core', 'rollMode'),
+      content
+    });
+  }
+
   async roll() {
     const item = this;
     let rollData, roll;
@@ -80,6 +136,8 @@ export class SwordsWizardryItem extends Item {
         roll = new AttackRoll(rollData.formula, rollData);
         await roll.render();
         return roll;
+      case 'spell':
+        return this.rollSpell();
       case 'feature':
         if (this.system.formula) {
           rollData = this.getRollData();
@@ -87,7 +145,6 @@ export class SwordsWizardryItem extends Item {
           await roll.render();
           return roll;
         }
-      case 'spell':
       case 'item':
       case 'armor':
         // TODO update this 

--- a/module/rolls/rolls.mjs
+++ b/module/rolls/rolls.mjs
@@ -63,17 +63,25 @@ export class AttackRoll extends Roll {
 export class DamageRoll extends Roll {
   async evaluate() {
     const result = await super.evaluate();
-	
-    if (!game.settings.get('swords-wizardry', 'dmAppliesDamage')) {
-      game.user.targets.forEach(async (target) => {
-        await rpc({
+
+    const isSpell = this.data.item?.type === 'spell';
+    const effectType = isSpell ? this.data.effectType ?? 'none' : 'damage';
+    const requiresSave = isSpell && Boolean(this.data.requiresSave);
+    if (
+      !game.settings.get('swords-wizardry', 'dmAppliesDamage')
+      && !requiresSave
+      && effectType !== 'none'
+    ) {
+      const amount = effectType === 'healing' ? result.total * -1 : result.total;
+      await Promise.all(Array.from(game.user.targets).map(target =>
+        rpc({
           recipient: 'GM',
           target: target.id,
           operation: 'damage',
-          amount: result.total,
-          data: { system: { hp: { value: target.actor.system.hp.value - result.total } } }
-        });
-      });
+          amount,
+          data: { system: { hp: { value: target.actor.system.hp.value - amount } } }
+        })
+      ));
     }
 
     return result;
@@ -81,22 +89,37 @@ export class DamageRoll extends Roll {
 
   async render(options) {
     const dmAppliesDamage = game.settings.get('swords-wizardry', 'dmAppliesDamage');
-
+    const isSpell = this.data.item?.type === 'spell';
+    const effectType = isSpell ? this.data.effectType ?? 'none' : 'damage';
+    const requiresSave = isSpell && Boolean(this.data.requiresSave);
+    const saveEffect = this.data.saveEffect === 'half' ? 'half' : 'negate';
     const speaker = ChatMessage.getSpeaker({ actor: this.data.actor });
     const rollMode = game.settings.get('core', 'rollMode');
     if (!this._evaluated) await this.evaluate();
     const rollHtml = await super.render();
-    const template = 'systems/swords-wizardry/module/rolls/damage-roll-sheet.hbs';
-	
+    const template = isSpell
+      ? 'systems/swords-wizardry/module/rolls/spell-roll-sheet.hbs'
+      : 'systems/swords-wizardry/module/rolls/damage-roll-sheet.hbs';
+
     const chatData = {
       item: this.data.item,
       actor: this.data.actor,
       roll: rollHtml,
       total: this.total,
-      dmAppliesDamage
+      dmAppliesDamage,
+      requiresSave,
+      saveEffectHalf: saveEffect === 'half',
+      fullAction: effectType === 'healing'
+        ? 'heal'
+        : effectType === 'damage' ? 'damage' : null,
+      saveAction: saveEffect === 'half'
+        ? effectType === 'healing' ? 'half-heal' : 'half'
+        : 'none'
     };
 
-    if (dmAppliesDamage) {
+    const needsManualApplication = effectType !== 'none'
+      && (dmAppliesDamage || requiresSave);
+    if (needsManualApplication || requiresSave) {
       const targets = Array.from(game.user.targets).map(t => ({
         id: t.id,
         name: t.name,
@@ -114,7 +137,7 @@ export class DamageRoll extends Roll {
     }
 
     const resultsHtml = await renderTemplate(template, chatData);
-    const msg = await SwordsWizardryChatMessage.create({
+    return SwordsWizardryChatMessage.create({
       rolls: [this],
       rollMode: rollMode,
       user: game.user._id,

--- a/module/rolls/spell-roll-sheet.hbs
+++ b/module/rolls/spell-roll-sheet.hbs
@@ -1,0 +1,77 @@
+<div class="swords-wizardry spell-card">
+  <header class="spell-card-header">
+    <img class="spell-card-image" src="{{item.img}}" alt=""/>
+    <div>
+      <h3>{{item.name}}</h3>
+      {{#if actor}}
+      <div>{{localize "SWORDS_WIZARDRY.Chat.CastBy"}} {{actor.name}}</div>
+      {{/if}}
+    </div>
+  </header>
+
+  <div class="spell-card-details">
+    <span>{{localize "SWORDS_WIZARDRY.Item.Spell.Level"}} {{item.system.spellLevel}}</span>
+    {{#if item.system.range}}
+    <span>{{localize "SWORDS_WIZARDRY.Item.Spell.Range"}} {{item.system.range}}</span>
+    {{/if}}
+    {{#if item.system.duration}}
+    <span>{{localize "SWORDS_WIZARDRY.Item.Spell.Duration"}} {{item.system.duration}}</span>
+    {{/if}}
+  </div>
+
+  {{#if item.system.description}}
+  <div class="spell-card-description">{{{item.system.description}}}</div>
+  {{/if}}
+
+  {{#if roll}}
+  <div class="spell-card-roll">{{{roll}}}</div>
+  {{/if}}
+
+  {{#if requiresSave}}
+  <div class="spell-card-save">
+    <strong>{{localize "SWORDS_WIZARDRY.Chat.SavingThrow"}}:</strong>
+    {{#if saveEffectHalf}}
+      {{localize "SWORDS_WIZARDRY.Chat.HalfEffect"}}
+    {{else}}
+      {{localize "SWORDS_WIZARDRY.Chat.NegatesSpell"}}
+    {{/if}}
+  </div>
+  {{/if}}
+
+  {{#if targets}}
+  <h4>{{localize "SWORDS_WIZARDRY.Chat.Targets"}}</h4>
+  <div class="damage-targets">
+    {{#each targets}}
+    <div class="damage-target">
+      <div class="target-name"><strong>{{name}}</strong></div>
+      {{#if ../fullAction}}
+      <div class="damage-buttons">
+        <button class="apply-damage"
+          data-action="{{../fullAction}}"
+          data-target-id="{{id}}"
+          data-amount="{{../total}}"
+          {{#if (lookup ../appliedDamage id)}}disabled{{/if}}>
+          {{localize "SWORDS_WIZARDRY.Chat.FullEffect"}}
+        </button>
+        {{#if ../requiresSave}}
+        <button class="apply-damage"
+          data-action="{{../saveAction}}"
+          data-target-id="{{id}}"
+          data-amount="{{../total}}"
+          {{#if (lookup ../appliedDamage id)}}disabled{{/if}}>
+          {{localize "SWORDS_WIZARDRY.Chat.SuccessfulSave"}}:
+          {{#if ../saveEffectHalf}}
+            {{localize "SWORDS_WIZARDRY.Chat.HalfEffect"}}
+          {{else}}
+            {{localize "SWORDS_WIZARDRY.Chat.NegatesSpell"}}
+          {{/if}}
+        </button>
+        {{/if}}
+      </div>
+      {{/if}}
+      <div class="damage-result"></div>
+    </div>
+    {{/each}}
+  </div>
+  {{/if}}
+</div>

--- a/module/scss/components/_messages.scss
+++ b/module/scss/components/_messages.scss
@@ -23,3 +23,34 @@
     font-size: 11px;
   }
 }
+
+.spell-card-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  h3 {
+    margin: 0;
+  }
+}
+
+.spell-card-image {
+  flex: 0 0 40px;
+  width: 40px;
+  height: 40px;
+  border: 0;
+}
+
+.spell-card-details {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 4px 12px;
+  margin-top: 6px;
+}
+
+.spell-card-description,
+.spell-card-roll,
+.spell-card-save {
+  margin-top: 6px;
+}

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -12,9 +12,9 @@ export function registerSystemSettings() {
     default: false
   });
 
-  // DM must apply damage
+  // DM must apply damage / healing
   game.settings.register("swords-wizardry", "dmAppliesDamage", {
-    name: "DM must apply damage",
+    name: "DM must apply damage / healing",
     scope: "world",
     config: true,
     type: Boolean,


### PR DESCRIPTION
Added some simple spell functionality to Spell items.

Spells have optional roll and saving throw fields.  Rolls can be defined as damage or healing, and saving throws can be flagged as half effect / negate effect / see description.

<img width="2250" height="1930" alt="image" src="https://github.com/user-attachments/assets/9a30ba14-4168-42a9-867e-a4106cbcb7b4" />
